### PR TITLE
Fix minor issues

### DIFF
--- a/IonDotnet.Tests/Integration/VectorBad.cs
+++ b/IonDotnet.Tests/Integration/VectorBad.cs
@@ -28,8 +28,6 @@ namespace IonDotnet.Tests.Integration
             "clobWithShortLiteralInlineCommentAtEnd.ion",
             "listWithClosingBrace.ion",
             "listWithClosingParen.ion",
-            "longStringSplitEscape_1.ion",
-            "longStringSplitEscape_2.ion",
             "longStringSplitEscape_3.ion",
             "offsetHours_1.ion",
             "offsetHours_2.ion",
@@ -41,13 +39,9 @@ namespace IonDotnet.Tests.Integration
             "shortUtf8Sequence_1.ion",
             "shortUtf8Sequence_2.ion",
             "shortUtf8Sequence_3.ion",
-            "string_3.ion",
-            "string_4.ion",
             "stringWithEof.ion",
             "structWithClosingBracket.ion",
             "structWithClosingParen.ion",
-            "symbol_10.ion",
-            "symbol_11.ion",
             "clobWithLongLiteralInlineCommentAtEnd.ion"
         };
 

--- a/IonDotnet/Internals/Text/TextConstants.cs
+++ b/IonDotnet/Internals/Text/TextConstants.cs
@@ -267,7 +267,7 @@ namespace IonDotnet.Internals.Text
             if (h >= 'A' && h <= 'F')
                 return h - 'A' + 10;
 
-            return -1;
+            throw new InvalidTokenException($"Invalid Hex character: { h }");
         }
 
         public static bool IsValidSymbolCharacter(int c)

--- a/IonDotnet/Internals/Text/TextConstants.cs
+++ b/IonDotnet/Internals/Text/TextConstants.cs
@@ -267,7 +267,7 @@ namespace IonDotnet.Internals.Text
             if (h >= 'A' && h <= 'F')
                 return h - 'A' + 10;
 
-            throw new InvalidTokenException($"Invalid Hex character: { h }");
+            throw new InvalidTokenException($"Invalid Hex value: { h }");
         }
 
         public static bool IsValidSymbolCharacter(int c)

--- a/IonDotnet/Internals/Text/TextScanner.cs
+++ b/IonDotnet/Internals/Text/TextScanner.cs
@@ -77,6 +77,8 @@ namespace IonDotnet.Internals.Text
                     var c2 = ReadChar();
                     if (c2 == ':')
                         return FinishNextToken(TextConstants.TokenDoubleColon, true);
+                    if (c2 == '}')
+                        throw new IonException("Unexpected }");
 
                     UnreadChar(c2);
                     return FinishNextToken(TextConstants.TokenColon, true);
@@ -95,7 +97,7 @@ namespace IonDotnet.Internals.Text
                 case '[':
                     return FinishNextToken(TextConstants.TokenOpenSquare, true);
                 case ']':
-                    return FinishNextToken(TextConstants.TokenCloseBrace, false);
+                    return FinishNextToken(TextConstants.TokenCloseSquare, false);
                 case '(':
                     return FinishNextToken(TextConstants.TokenOpenParen, true);
                 case ')':


### PR DESCRIPTION
The 3 changes in this pull request:

_TextScanner.cs:_

- Line 80: we should not see } character right after : 
The only case where this might cause problem is in structs as they start with { and closing bracket is excepted is that stream, but yet, it should not appear after : 
- Line 100: Typo, I assume, causing unexpected behaviour.

_TextConstants.cs:_

- The method is supposed to return the equivalent value of the given hexadecimal character. If the given character is not hexadecimal, then something is wrong and to me throwing exception is more appropriate than returning -1 .
BTW, This method has only one usage in the project.