### PR TITLE
Fix clob issues

### DIFF
--- a/IonDotnet.Tests/Integration/VectorBad.cs
+++ b/IonDotnet.Tests/Integration/VectorBad.cs
@@ -14,18 +14,6 @@ namespace IonDotnet.Tests.Integration
     {
         private static readonly HashSet<string> Excludes = new HashSet<string>
         {
-            "clob_3.ion",
-            "clob_4.ion",
-            "clob_5.ion",
-            "clob_6.ion",
-            "clob_7.ion",
-            "clob_8.ion",
-            "clob_9.ion",
-            "clobWithLongLiteralBlockCommentAtEnd.ion",
-            "clobWithLongLiteralCommentsInMiddle.ion",
-            "clobWithNonAsciiCharacter.ion",
-            "clobWithShortLiteralBlockCommentAtEnd.ion",
-            "clobWithShortLiteralInlineCommentAtEnd.ion",
             "listWithClosingBrace.ion",
             "listWithClosingParen.ion",
             "longStringSplitEscape_1.ion",
@@ -48,7 +36,6 @@ namespace IonDotnet.Tests.Integration
             "structWithClosingParen.ion",
             "symbol_10.ion",
             "symbol_11.ion",
-            "clobWithLongLiteralInlineCommentAtEnd.ion"
         };
 
         private static readonly DirectoryInfo IonTestDir = DirStructure.IonTestDir();

--- a/IonDotnet/Internals/Text/TextScanner.cs
+++ b/IonDotnet/Internals/Text/TextScanner.cs
@@ -1964,11 +1964,6 @@ namespace IonDotnet.Internals.Text
             while (true)
             {
                 var c = ReadTripleQuotedChar(isClob);
-                // CLOB texts should be only 7-bit ASCII characters
-                if (isClob)
-                {
-                    Required7BitChar(c);
-                }
                 switch (c)
                 {
                     case CharacterSequence.CharSeqStringTerminator:
@@ -2013,6 +2008,11 @@ namespace IonDotnet.Internals.Text
                     //                        sb.Append(Characters.GetHighSurrogate(c));
                     //                        c = Characters.GetLowSurrogate(c);
                     //                    }
+                }
+                else
+                {
+                    // CLOB texts should be only 7-bit ASCII characters
+                    Required7BitChar(c);
                 }
 
                 sb.Append((char)c);

--- a/IonDotnet/Internals/Text/TextScanner.cs
+++ b/IonDotnet/Internals/Text/TextScanner.cs
@@ -1460,7 +1460,7 @@ namespace IonDotnet.Internals.Text
 
         /// <summary>
         /// Any CLOB with double quote, can hold only one " " and the only
-        /// acceptable character after the second double quote is }}
+        /// acceptable character after the second double quote is }
         /// </summary>
         private void HandleClobsWithDoubleQuote()
         {

--- a/IonDotnet/Internals/Text/TextScanner.cs
+++ b/IonDotnet/Internals/Text/TextScanner.cs
@@ -992,9 +992,9 @@ namespace IonDotnet.Internals.Text
             {
                 var c = ReadStringChar(Characters.ProhibitionContext.ShortChar);
                 // CLOB texts should be only 7-bit ASCII characters
-                if (isClob && !Characters.Is7BitChar(c))
+                if (isClob)
                 {
-                    throw new IonException($"Illegal character: {(char)c}. All characters must be 7-bit ASCII");
+                    Required7BitChar(c);
                 }
                 switch (c)
                 {
@@ -1964,6 +1964,11 @@ namespace IonDotnet.Internals.Text
             while (true)
             {
                 var c = ReadTripleQuotedChar(isClob);
+                // CLOB texts should be only 7-bit ASCII characters
+                if (isClob)
+                {
+                    Required7BitChar(c);
+                }
                 switch (c)
                 {
                     case CharacterSequence.CharSeqStringTerminator:
@@ -2011,6 +2016,14 @@ namespace IonDotnet.Internals.Text
                 }
 
                 sb.Append((char)c);
+            }
+        }
+
+        private void Required7BitChar(int c)
+        {
+            if (!Characters.Is7BitChar(c))
+            {
+                throw new IonException($"Illegal character: {(char)c}. All characters must be 7-bit ASCII");
             }
         }
 

--- a/IonDotnet/Internals/Text/TextScanner.cs
+++ b/IonDotnet/Internals/Text/TextScanner.cs
@@ -994,7 +994,7 @@ namespace IonDotnet.Internals.Text
                 // CLOB texts should be only 7-bit ASCII characters
                 if (isClob)
                 {
-                    Required7BitChar(c);
+                    Require7BitChar(c);
                 }
                 switch (c)
                 {
@@ -1467,7 +1467,7 @@ namespace IonDotnet.Internals.Text
             var c = SkipOverWhiteSpace(CommentStrategy.Error);
             if (c != '}')
             {
-                throw new IonException($"Invalid character format: {(char)c}");
+                throw new IonException($"Bad Character in Clob:: { ((char)c) } , expected \"}}}}\"");
             }
             UnreadChar(c);
         }
@@ -1926,7 +1926,7 @@ namespace IonDotnet.Internals.Text
                         // so the only acceptable charcter is the closing brace
                         if (isClob && c != '}')
                         {
-                            throw new IonException($"Bad Character: { ((char)c) } , expected \"}}}}\"");
+                            throw new IonException($"Bad Character in Clob: { ((char)c) } , expected \"}}}}\"");
                         }
 
                         // end of last segment - we're done (although we read a bit too far)
@@ -2012,14 +2012,14 @@ namespace IonDotnet.Internals.Text
                 else
                 {
                     // CLOB texts should be only 7-bit ASCII characters
-                    Required7BitChar(c);
+                    Require7BitChar(c);
                 }
 
                 sb.Append((char)c);
             }
         }
 
-        private void Required7BitChar(int c)
+        private void Require7BitChar(int c)
         {
             if (!Characters.Is7BitChar(c))
             {

--- a/IonDotnet/Utils/Characters.cs
+++ b/IonDotnet/Utils/Characters.cs
@@ -175,8 +175,8 @@ namespace IonDotnet.Utils
 //            return (char) ((c | LowSurrogate) & 0xffff);
 //        }
 
-//        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-//        public static bool Is7BitChar(int c) => (c & ~0x7f) == 0;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool Is7BitChar(int c) => (c & ~0x7f) == 0;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool Is8BitChar(int c) => (c & ~0xff) == 0;


### PR DESCRIPTION
_Issues with CLOBs_

_Description of changes:_
This pull request mainly addresses the following points:

- clob can contain only 7-bit ASCII characters
- clobs cannot have any comments within the value
- only 1 pair of double quoted value can exist in a clob. eg: {{ "a" "b" }} is not allowed
- multiple ''' values can combine in one clobs, however only ''' values can be defined in such clobs. In other words, '''a''' and "b" cannot be in the same clob.