### PR TITLE
Fix unclosed double quote

### DIFF
--- a/IonDotnet.Tests/Integration/VectorBad.cs
+++ b/IonDotnet.Tests/Integration/VectorBad.cs
@@ -43,7 +43,6 @@ namespace IonDotnet.Tests.Integration
             "shortUtf8Sequence_3.ion",
             "string_3.ion",
             "string_4.ion",
-            "stringWithEof.ion",
             "structWithClosingBracket.ion",
             "structWithClosingParen.ion",
             "symbol_10.ion",

--- a/IonDotnet.Tests/Integration/VectorBad.cs
+++ b/IonDotnet.Tests/Integration/VectorBad.cs
@@ -26,6 +26,7 @@ namespace IonDotnet.Tests.Integration
             "clobWithNonAsciiCharacter.ion",
             "clobWithShortLiteralBlockCommentAtEnd.ion",
             "clobWithShortLiteralInlineCommentAtEnd.ion",
+            "clobWithLongLiteralInlineCommentAtEnd.ion",
             "listWithClosingBrace.ion",
             "listWithClosingParen.ion",
             "longStringSplitEscape_1.ion",
@@ -46,8 +47,7 @@ namespace IonDotnet.Tests.Integration
             "structWithClosingBracket.ion",
             "structWithClosingParen.ion",
             "symbol_10.ion",
-            "symbol_11.ion",
-            "clobWithLongLiteralInlineCommentAtEnd.ion"
+            "symbol_11.ion"
         };
 
         private static readonly DirectoryInfo IonTestDir = DirStructure.IonTestDir();

--- a/IonDotnet/Internals/Text/TextScanner.cs
+++ b/IonDotnet/Internals/Text/TextScanner.cs
@@ -998,6 +998,8 @@ namespace IonDotnet.Internals.Text
                     case CharacterSequence.CharSeqEscapedNewlineSequence3:
                         continue;
                     case -1:
+                        FinishNextToken(isClob ? Token : TextConstants.TokenStringDoubleQuote, isClob);
+                        return Token == TextConstants.TokenStringDoubleQuote ? TextConstants.TokenEof : c;
                     case '"':
                         FinishNextToken(isClob ? Token : TextConstants.TokenStringDoubleQuote, isClob);
                         return c;


### PR DESCRIPTION
_String without closing ":_
Having DoubleQuote as Token in LoadDoubleQuotedString() means we are parsing a string, which should end with a " if we get -1 it is an unexpected EOF