### PR TITLE
Fix unclosed triple quote

### DIFF
--- a/IonDotnet.Tests/Integration/VectorBad.cs
+++ b/IonDotnet.Tests/Integration/VectorBad.cs
@@ -14,7 +14,6 @@ namespace IonDotnet.Tests.Integration
     {
         private static readonly HashSet<string> Excludes = new HashSet<string>
         {
-            "longStringSplitEscape_3.ion",
             "shortUtf8Sequence_1.ion",
             "shortUtf8Sequence_2.ion",
             "shortUtf8Sequence_3.ion"

--- a/IonDotnet/Internals/Text/TextScanner.cs
+++ b/IonDotnet/Internals/Text/TextScanner.cs
@@ -1970,9 +1970,11 @@ namespace IonDotnet.Internals.Text
                 switch (c)
                 {
                     case CharacterSequence.CharSeqStringTerminator:
-                    case CharacterSequence.CharSeqEof: // was 
                         FinishNextToken(isClob ? Token : TextConstants.TokenStringTripleQuote, isClob);
                         return c;
+                    case CharacterSequence.CharSeqEof: // was
+                        FinishNextToken(isClob ? Token : TextConstants.TokenStringTripleQuote, isClob);
+                        return Token == TextConstants.TokenStringTripleQuote ? TextConstants.TokenEof : c;
                     // new line normalization and counting is handled in read_char
                     case CharacterSequence.CharSeqNewlineSequence1:
                         c = '\n';

--- a/IonDotnet/Internals/Text/TextScanner.cs
+++ b/IonDotnet/Internals/Text/TextScanner.cs
@@ -1972,7 +1972,7 @@ namespace IonDotnet.Internals.Text
                     case CharacterSequence.CharSeqStringTerminator:
                         FinishNextToken(isClob ? Token : TextConstants.TokenStringTripleQuote, isClob);
                         return c;
-                    case CharacterSequence.CharSeqEof: // was
+                    case CharacterSequence.CharSeqEof:
                         FinishNextToken(isClob ? Token : TextConstants.TokenStringTripleQuote, isClob);
                         return Token == TextConstants.TokenStringTripleQuote ? TextConstants.TokenEof : c;
                     // new line normalization and counting is handled in read_char


### PR DESCRIPTION
String without closing '''
Having triple quote as token in LoadTripleQuotedString() means we are parsing a string, which should end with a ''' if we get -1 it is an unexpected EOF

Similar fix to #11 