### PR TITLE
Fix binary encodings of IonType

### DIFF
--- a/IonDotnet/IonType.cs
+++ b/IonDotnet/IonType.cs
@@ -5,18 +5,19 @@
         None = -1,
         Null = 0,
         Bool = 1,
+        // note that INT is actually 0x2 **and** 0x3 in the Ion binary encoding
         Int = 2,
-        Float = 3,
-        Decimal = 4,
-        Timestamp = 5,
-        Symbol = 6,
-        String = 7,
-        Clob = 8,
-        Blob = 9,
-        List = 10,
-        Sexp = 11,
-        Struct = 12,
-        Datagram = 13
+        Float = 4,
+        Decimal = 5,
+        Timestamp = 6,
+        Symbol = 7,
+        String = 8,
+        Clob = 9,
+        Blob = 10,
+        List = 11,
+        Sexp = 12,
+        Struct = 13,
+        Datagram = 14
     }
 
     public static class IonTypeExtensions


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:*
Align the Ion types with the Ion binary type codes per the [docs](http://amzn.github.io/ion-docs/docs/binary.html)

I decided to keep the IonType.None. Enums are value types, and can't be null. A workaround to this is to make the enum a [nullable type](https://stackoverflow.com/questions/4337193/how-to-set-enum-to-null/4337236#4337236) wherever we use it. But it is standard practice to have an enum value that signifies none.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.