### PR TITLE
Switches SSH submodule URL to HTTPS.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ion-tests"]
 	path = ion-tests
-	url = git@github.com:amzn/ion-tests.git
+	url = https://github.com/amzn/ion-tests.git


### PR DESCRIPTION
This is consistent with our other modules and is in line with Github recommendations:

https://help.github.com/en/github/using-git/which-remote-url-should-i-use

I ran into issues because I did an HTTPS clone, but the SSH submodule was problematic because I did not have an SSH key registered with Github.  This should make it easier for unauthenticated users to clone the repo.

I've also done a recursive clone of my fork to make sure it behaves appropriately:

```
$ git clone --recursive https://github.com/almann/ion-dotnet.git
Cloning into 'ion-dotnet'...
remote: Enumerating objects: 74, done.
remote: Counting objects: 100% (74/74), done.
remote: Compressing objects: 100% (70/70), done.
remote: Total 3323 (delta 20), reused 9 (delta 4), pack-reused 3249
Receiving objects: 100% (3323/3323), 758.34 KiB | 9.36 MiB/s, done.
Resolving deltas: 100% (2575/2575), done.
Submodule 'ion-tests' (https://github.com/amzn/ion-tests.git) registered for path 'ion-tests'
Cloning into '/home/ANT.AMAZON.COM/almann/Scratch/ion-dotnet/ion-tests'...
remote: Enumerating objects: 88, done.        
remote: Counting objects: 100% (88/88), done.        
remote: Compressing objects: 100% (60/60), done.        
remote: Total 1103 (delta 45), reused 65 (delta 24), pack-reused 1015        
Receiving objects: 100% (1103/1103), 137.03 KiB | 7.61 MiB/s, done.
Resolving deltas: 100% (244/244), done.
Submodule path 'ion-tests': checked out 'b4b1d8739bf10ac5154ae874b9332ddcdf387e62'
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
