### PR TITLE
Fix utf-16 surrogate pairs

### DIFF
--- a/IonDotnet.Tests/Integration/VectorBad.cs
+++ b/IonDotnet.Tests/Integration/VectorBad.cs
@@ -16,10 +16,7 @@ namespace IonDotnet.Tests.Integration
         {
             "shortUtf8Sequence_1.ion",
             "shortUtf8Sequence_2.ion",
-            "shortUtf8Sequence_3.ion",
-            "surrogate_6.ion",
-            "surrogate_7.ion",
-            "surrogate_8.ion"
+            "shortUtf8Sequence_3.ion"
         };
 
         private static readonly DirectoryInfo IonTestDir = DirStructure.IonTestDir();

--- a/IonDotnet/Internals/Text/TextScanner.cs
+++ b/IonDotnet/Internals/Text/TextScanner.cs
@@ -1029,11 +1029,17 @@ namespace IonDotnet.Internals.Text
                         //                        break;
                 }
 
-                if (!isClob && char.IsHighSurrogate((char)c))
-                {
-                    sb.Append((char)c);
-                    c = ReadChar();
-                    if (!char.IsLowSurrogate((char)c))
+                if (!isClob) {
+                    if (char.IsHighSurrogate((char)c))
+                    {
+                        sb.Append((char)c);
+                        c = ReadChar();
+                        if (!char.IsLowSurrogate((char)c))
+                        {
+                            throw new IonException($"Invalid character format {(char)c}");
+                        }
+                    }
+                    else if (char.IsLowSurrogate((char)c))
                     {
                         throw new IonException($"Invalid character format {(char)c}");
                     }
@@ -1125,6 +1131,10 @@ namespace IonDotnet.Internals.Text
                         {
                             throw new IonException($"Invalid character format {(char)c}");
                         }
+                    }
+                    else if (char.IsLowSurrogate((char)c))
+                    {
+                        throw new IonException($"Invalid character format {(char)c}");
                     }
                 }
                 else if (Characters.Is8BitChar(c))
@@ -2005,7 +2015,10 @@ namespace IonDotnet.Internals.Text
                             throw new IonException($"Invalid character format {(char)c}");
                         }
                     }
-
+                    else if (char.IsLowSurrogate((char)c))
+                    {
+                        throw new IonException($"Invalid character format {(char)c}");
+                    }
                     //                    sb.Append(c);
                     //
                     //                    if (Characters.NeedsSurrogateEncoding(c))


### PR DESCRIPTION
Missing logic for low surrogate.
Implemented the same logic from [Java](https://github.com/amzn/ion-java/blob/master/src/com/amazon/ion/util/IonTextUtils.java#L723) and [Python](https://github.com/amzn/ion-python/blob/master/amazon/ion/util.py#L261).