### PR TITLE
Fix for malformed utf8 sequence

### DIFF
--- a/Amazon.IonDotnet.Tests/Integration/Vector.cs
+++ b/Amazon.IonDotnet.Tests/Integration/Vector.cs
@@ -42,7 +42,8 @@ namespace Amazon.IonDotnet.Tests.Integration
         {
             "subfieldVarInt.ion",
             "whitespace.ion",
-            "localSymbolTableAppend.ion"
+            "localSymbolTableAppend.ion",
+            "stringUtf8.ion"
         };
 
         private static readonly DirectoryInfo IonTestDir = DirStructure.IonTestDir();

--- a/Amazon.IonDotnet.Tests/Integration/Vector.cs
+++ b/Amazon.IonDotnet.Tests/Integration/Vector.cs
@@ -41,9 +41,8 @@ namespace Amazon.IonDotnet.Tests.Integration
         private static readonly HashSet<string> Excludes = new HashSet<string>
         {
             "subfieldVarInt.ion",
-            "whitespace.ion",
             "localSymbolTableAppend.ion",
-            "stringUtf8.ion"
+            "clobNewlines.ion"
         };
 
         private static readonly DirectoryInfo IonTestDir = DirStructure.IonTestDir();

--- a/Amazon.IonDotnet.Tests/Integration/Vector.cs
+++ b/Amazon.IonDotnet.Tests/Integration/Vector.cs
@@ -41,8 +41,8 @@ namespace Amazon.IonDotnet.Tests.Integration
         private static readonly HashSet<string> Excludes = new HashSet<string>
         {
             "subfieldVarInt.ion",
-            "localSymbolTableAppend.ion",
-            "clobNewlines.ion"
+            "whitespace.ion",
+            "localSymbolTableAppend.ion"
         };
 
         private static readonly DirectoryInfo IonTestDir = DirStructure.IonTestDir();

--- a/Amazon.IonDotnet.Tests/Integration/Vector.cs
+++ b/Amazon.IonDotnet.Tests/Integration/Vector.cs
@@ -42,8 +42,7 @@ namespace Amazon.IonDotnet.Tests.Integration
         {
             "subfieldVarInt.ion",
             "whitespace.ion",
-            "localSymbolTableAppend.ion",
-            "stringUtf8.ion"
+            "localSymbolTableAppend.ion"
         };
 
         private static readonly DirectoryInfo IonTestDir = DirStructure.IonTestDir();

--- a/Amazon.IonDotnet.Tests/Integration/VectorBad.cs
+++ b/Amazon.IonDotnet.Tests/Integration/VectorBad.cs
@@ -29,9 +29,8 @@ namespace Amazon.IonDotnet.Tests.Integration
     {
         private static readonly HashSet<string> Excludes = new HashSet<string>
         {
-            "shortUtf8Sequence_1.ion",
-            "shortUtf8Sequence_2.ion",
-            "shortUtf8Sequence_3.ion"
+            // To exclude a test file of ion-test submodule from running, add the 
+            // test file with its extension here. For example: "test.ion"
         };
 
         private static readonly DirectoryInfo IonTestDir = DirStructure.IonTestDir();


### PR DESCRIPTION
*Issue #36 :*

*Description of changes:*
If ``StreamReader.Read()`` returns -1 while the stream still has bytes, an exception will be thrown as the stream cannot be parsed as a valid stream,