### PR TITLE
Fix IonType enum's IsScalar() function

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ion-tests"]
 	path = ion-tests
-	url = git@github.com:amzn/ion-tests.git
+	url = https://github.com/amzn/ion-tests.git

--- a/IonDotnet.Tests/Builders/LoaderTest.cs
+++ b/IonDotnet.Tests/Builders/LoaderTest.cs
@@ -22,10 +22,10 @@ namespace IonDotnet.Tests.Builders
 
             Assert.AreEqual(3, datagram.Count);
 
-            int i = 0;
+            int counter = 0;
             foreach (var ionValue in datagram)
             {
-                CascadingSymtabAssertion(ionValue, i++);
+                CascadingSymtabAssertion(ionValue, counter++);
             }
         }
 

--- a/IonDotnet.Tests/Builders/LoaderTest.cs
+++ b/IonDotnet.Tests/Builders/LoaderTest.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using IonDotnet.Builders;
 using IonDotnet.Tests.Common;
+using IonDotnet.Tree;
 using IonDotnet.Tree.Impl;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -21,23 +22,32 @@ namespace IonDotnet.Tests.Builders
 
             Assert.AreEqual(3, datagram.Count);
 
-            //the first value $13 should be unknown text
-            Assert.AreEqual(IonType.Symbol, datagram[0].Type);
-            var token = ((IonSymbol) datagram[0]).SymbolValue;
-            Assert.AreEqual(13, token.Sid);
-            Assert.IsNull(token.Text);
+            int i = 0;
+            foreach (var ionValue in datagram)
+            {
+                CascadingSymtabAssertion(ionValue, i++);
+            }
+        }
 
-            //2nd value $10 should be rock:10
-            Assert.AreEqual(IonType.Symbol, datagram[1].Type);
-            token = ((IonSymbol) datagram[1]).SymbolValue;
-            Assert.AreEqual(10, token.Sid);
-            Assert.AreEqual("rock", token.Text);
-
-            //3rd value $10 should be unknown text
-            Assert.AreEqual(IonType.Symbol, datagram[0].Type);
-            token = ((IonSymbol) datagram[2]).SymbolValue;
-            Assert.AreEqual(10, token.Sid);
-            Assert.IsNull(token.Text);
+        private void CascadingSymtabAssertion(IIonValue ionValue, int itemNumber)
+        {
+            Assert.AreEqual(IonType.Symbol, ionValue.Type());
+            var token = ((IonSymbol)ionValue).SymbolValue;
+            switch (itemNumber)
+            {
+                case 0:
+                    Assert.AreEqual(13, token.Sid);
+                    Assert.IsNull(token.Text);
+                    break;
+                case 1:
+                    Assert.AreEqual(10, token.Sid);
+                    Assert.AreEqual("rock", token.Text);
+                    break;
+                case 2:
+                    Assert.AreEqual(10, token.Sid);
+                    Assert.IsNull(token.Text);
+                    break;
+            }
         }
 
         [TestMethod]
@@ -46,10 +56,13 @@ namespace IonDotnet.Tests.Builders
             const string doc = "$3::123";
             var datagram = IonLoader.Default.Load(doc);
 
-            var child = (IonInt) datagram[0];
-            var annots = child.GetTypeAnnotations();
-            Assert.AreEqual(1, annots.Count);
-            Assert.AreEqual(SystemSymbols.IonSymbolTable, annots.First().Text);
+            foreach (var ionValue in datagram)
+            {
+                var child = (IonInt)ionValue;
+                var annots = child.GetTypeAnnotations();
+                Assert.AreEqual(1, annots.Count);
+                Assert.AreEqual(SystemSymbols.IonSymbolTable, annots.First().Text);
+            }
         }
 
         [TestMethod]
@@ -57,8 +70,11 @@ namespace IonDotnet.Tests.Builders
         {
             const string doc = "{{'''hello'''}}";
             var datagram = IonLoader.Default.Load(doc);
-            var child = (IonClob) datagram[0];
-            Assert.AreEqual("hello".Length, child.Bytes().Length);
+            foreach (var ionValue in datagram)
+            {
+                var child = (IonClob)ionValue;
+                Assert.AreEqual("hello".Length, child.Bytes().Length);
+            }
         }
     }
 }

--- a/IonDotnet.Tests/Builders/LoaderTest.cs
+++ b/IonDotnet.Tests/Builders/LoaderTest.cs
@@ -32,7 +32,7 @@ namespace IonDotnet.Tests.Builders
         private void CascadingSymtabAssertion(IIonValue ionValue, int itemNumber)
         {
             Assert.AreEqual(IonType.Symbol, ionValue.Type());
-            var token = ((IonSymbol)ionValue).SymbolValue;
+            var token = ionValue.SymbolValue;
             switch (itemNumber)
             {
                 case 0:
@@ -55,10 +55,11 @@ namespace IonDotnet.Tests.Builders
         {
             const string doc = "$3::123";
             var datagram = IonLoader.Default.Load(doc);
-
+            Assert.AreEqual(1, datagram.Count);
             foreach (var ionValue in datagram)
             {
-                var child = (IonInt)ionValue;
+                var child = ionValue;
+                Assert.AreEqual(0, datagram.IndexOf(child));
                 var annots = child.GetTypeAnnotations();
                 Assert.AreEqual(1, annots.Count);
                 Assert.AreEqual(SystemSymbols.IonSymbolTable, annots.First().Text);
@@ -70,9 +71,11 @@ namespace IonDotnet.Tests.Builders
         {
             const string doc = "{{'''hello'''}}";
             var datagram = IonLoader.Default.Load(doc);
+            Assert.AreEqual(1, datagram.Count);
             foreach (var ionValue in datagram)
             {
-                var child = (IonClob)ionValue;
+                var child = ionValue;
+                Assert.AreEqual(0, datagram.IndexOf(child));
                 Assert.AreEqual("hello".Length, child.Bytes().Length);
             }
         }

--- a/IonDotnet.Tests/Builders/LoaderTest.cs
+++ b/IonDotnet.Tests/Builders/LoaderTest.cs
@@ -56,14 +56,10 @@ namespace IonDotnet.Tests.Builders
             const string doc = "$3::123";
             var datagram = IonLoader.Default.Load(doc);
             Assert.AreEqual(1, datagram.Count);
-            foreach (var ionValue in datagram)
-            {
-                var child = ionValue;
-                Assert.AreEqual(0, datagram.IndexOf(child));
-                var annots = child.GetTypeAnnotations();
-                Assert.AreEqual(1, annots.Count);
-                Assert.AreEqual(SystemSymbols.IonSymbolTable, annots.First().Text);
-            }
+            var child = datagram.GetElementAt(0);
+            var annots = child.GetTypeAnnotations();
+            Assert.AreEqual(1, annots.Count);
+            Assert.AreEqual(SystemSymbols.IonSymbolTable, annots.First().Text);
         }
 
         [TestMethod]
@@ -72,12 +68,8 @@ namespace IonDotnet.Tests.Builders
             const string doc = "{{'''hello'''}}";
             var datagram = IonLoader.Default.Load(doc);
             Assert.AreEqual(1, datagram.Count);
-            foreach (var ionValue in datagram)
-            {
-                var child = ionValue;
-                Assert.AreEqual(0, datagram.IndexOf(child));
-                Assert.AreEqual("hello".Length, child.Bytes().Length);
-            }
+            var child = datagram.GetElementAt(0);
+            Assert.AreEqual("hello".Length, child.Bytes().Length);
         }
     }
 }

--- a/IonDotnet.Tests/Integration/Vector.cs
+++ b/IonDotnet.Tests/Integration/Vector.cs
@@ -268,9 +268,26 @@ namespace IonDotnet.Tests.Integration
 
         private static bool AssertDatagramEquivalent(IIonValue d1, IIonValue d2)
         {
-            //TODO: FIX
-            var eq = true; // d1.SequenceEqual(d2, IonValueComparer);
+            IonValue[] values1 = GetIonValues(d1);
+            IonValue[] values2 = GetIonValues(d2);
+
+            var eq = values1.SequenceEqual(values2, IonValueComparer);
             return eq;
+        }
+
+        private static IonValue[] GetIonValues(IIonValue value)
+        {
+            if (value is null)
+                return new IonValue[0];
+
+            IonValue[] ionValues = new IonValue[value.Count];
+            int counter = 0;
+            foreach (var ionValue in value)
+            {
+                ionValues[counter++] = (IonValue)ionValue;
+            }
+
+            return ionValues;
         }
 
         private static IIonValue LoadFile(FileInfo fi, out ISymbolTable readerTable)

--- a/IonDotnet.Tests/Integration/Vector.cs
+++ b/IonDotnet.Tests/Integration/Vector.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Text;
 using IonDotnet.Builders;
 using IonDotnet.Tests.Common;
+using IonDotnet.Tree;
 using IonDotnet.Tree.Impl;
 using IonDotnet.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -118,7 +119,7 @@ namespace IonDotnet.Tests.Integration
             RoundTrip_AssertBinary(datagram, readerTable);
         }
 
-        private static void RoundTrip_AssertText(IonDatagram datagram, ISymbolTable readerTable)
+        private static void RoundTrip_AssertText(IIonValue datagram, ISymbolTable readerTable)
         {
             var sw = new StringWriter();
             var writer = IonTextWriterBuilder.Build(sw, new IonTextOptions {PrettyPrint = true}, readerTable.GetImportedTables());
@@ -131,7 +132,7 @@ namespace IonDotnet.Tests.Integration
             AssertDatagramEquivalent(datagram, datagram2);
         }
 
-        private static void RoundTrip_AssertBinary(IonDatagram datagram, ISymbolTable readerTable)
+        private static void RoundTrip_AssertBinary(IIonValue datagram, ISymbolTable readerTable)
         {
             using (var ms = new MemoryStream())
             {
@@ -226,8 +227,8 @@ namespace IonDotnet.Tests.Integration
                         var equiv = seqChild.IsEquivalentTo(seqChild2);
                         if (equiv)
                         {
-                            Console.WriteLine(seqChild.Type + seqChild.ToPrettyString());
-                            Console.WriteLine(seqChild2.Type + seqChild2.ToPrettyString());
+                            Console.WriteLine(seqChild.Type() + seqChild.ToPrettyString());
+                            Console.WriteLine(seqChild2.Type() + seqChild2.ToPrettyString());
                             Console.WriteLine(i);
                             equiv = seqChild.IsEquivalentTo(seqChild2);
                         }
@@ -265,13 +266,14 @@ namespace IonDotnet.Tests.Integration
             }
         }
 
-        private static bool AssertDatagramEquivalent(IonDatagram d1, IonDatagram d2)
+        private static bool AssertDatagramEquivalent(IIonValue d1, IIonValue d2)
         {
-            var eq = d1.SequenceEqual(d2, IonValueComparer);
+            //TODO: FIX
+            var eq = true; // d1.SequenceEqual(d2, IonValueComparer);
             return eq;
         }
 
-        private static IonDatagram LoadFile(FileInfo fi, out ISymbolTable readerTable)
+        private static IIonValue LoadFile(FileInfo fi, out ISymbolTable readerTable)
         {
             if (fi.Name == "utf16.ion")
             {
@@ -291,7 +293,7 @@ namespace IonDotnet.Tests.Integration
             return tree;
         }
 
-        private static IonDatagram LoadFile(FileInfo fi) => LoadFile(fi, out _);
+        private static IIonValue LoadFile(FileInfo fi) => LoadFile(fi, out _);
 
         private class ValueComparer : IEqualityComparer<IonValue>
         {

--- a/IonDotnet.Tests/Integration/Vector.cs
+++ b/IonDotnet.Tests/Integration/Vector.cs
@@ -119,11 +119,11 @@ namespace IonDotnet.Tests.Integration
             RoundTrip_AssertBinary(datagram, readerTable);
         }
 
-        private static void RoundTrip_AssertText(IIonDatagram datagram, ISymbolTable readerTable)
+        private static void RoundTrip_AssertText(IIonValue datagram, ISymbolTable readerTable)
         {
             var sw = new StringWriter();
             var writer = IonTextWriterBuilder.Build(sw, new IonTextOptions {PrettyPrint = true}, readerTable.GetImportedTables());
-            ((IIonValue)datagram).WriteTo(writer);
+            datagram.WriteTo(writer);
             writer.Finish();
             var text = sw.ToString();
             Console.WriteLine(text);
@@ -132,13 +132,13 @@ namespace IonDotnet.Tests.Integration
             AssertDatagramEquivalent(datagram, datagram2);
         }
 
-        private static void RoundTrip_AssertBinary(IIonDatagram datagram, ISymbolTable readerTable)
+        private static void RoundTrip_AssertBinary(IIonValue datagram, ISymbolTable readerTable)
         {
             using (var ms = new MemoryStream())
             {
                 using (var writer = IonBinaryWriterBuilder.Build(ms, readerTable.GetImportedTables()))
                 {
-                    ((IIonValue)datagram).WriteTo(writer);
+                    datagram.WriteTo(writer);
                     writer.Finish();
                     var bin = ms.ToArray();
                     var catalog = Symbols.GetReaderCatalog(readerTable);
@@ -266,7 +266,7 @@ namespace IonDotnet.Tests.Integration
             }
         }
 
-        private static bool AssertDatagramEquivalent(IIonDatagram d1, IIonDatagram d2)
+        private static bool AssertDatagramEquivalent(IIonValue d1, IIonValue d2)
         {
             IonValue[] values1 = GetIonValues(d1);
             IonValue[] values2 = GetIonValues(d2);
@@ -275,7 +275,7 @@ namespace IonDotnet.Tests.Integration
             return eq;
         }
 
-        private static IonValue[] GetIonValues(IIonDatagram value)
+        private static IonValue[] GetIonValues(IIonValue value)
         {
             if (value is null)
                 return new IonValue[0];
@@ -290,7 +290,7 @@ namespace IonDotnet.Tests.Integration
             return ionValues;
         }
 
-        private static IIonDatagram LoadFile(FileInfo fi, out ISymbolTable readerTable)
+        private static IIonValue LoadFile(FileInfo fi, out ISymbolTable readerTable)
         {
             if (fi.Name == "utf16.ion")
             {
@@ -310,7 +310,7 @@ namespace IonDotnet.Tests.Integration
             return tree;
         }
 
-        private static IIonDatagram LoadFile(FileInfo fi) => LoadFile(fi, out _);
+        private static IIonValue LoadFile(FileInfo fi) => LoadFile(fi, out _);
 
         private class ValueComparer : IEqualityComparer<IonValue>
         {

--- a/IonDotnet.Tests/Integration/Vector.cs
+++ b/IonDotnet.Tests/Integration/Vector.cs
@@ -119,11 +119,11 @@ namespace IonDotnet.Tests.Integration
             RoundTrip_AssertBinary(datagram, readerTable);
         }
 
-        private static void RoundTrip_AssertText(IIonValue datagram, ISymbolTable readerTable)
+        private static void RoundTrip_AssertText(IIonDatagram datagram, ISymbolTable readerTable)
         {
             var sw = new StringWriter();
             var writer = IonTextWriterBuilder.Build(sw, new IonTextOptions {PrettyPrint = true}, readerTable.GetImportedTables());
-            datagram.WriteTo(writer);
+            ((IIonValue)datagram).WriteTo(writer);
             writer.Finish();
             var text = sw.ToString();
             Console.WriteLine(text);
@@ -132,13 +132,13 @@ namespace IonDotnet.Tests.Integration
             AssertDatagramEquivalent(datagram, datagram2);
         }
 
-        private static void RoundTrip_AssertBinary(IIonValue datagram, ISymbolTable readerTable)
+        private static void RoundTrip_AssertBinary(IIonDatagram datagram, ISymbolTable readerTable)
         {
             using (var ms = new MemoryStream())
             {
                 using (var writer = IonBinaryWriterBuilder.Build(ms, readerTable.GetImportedTables()))
                 {
-                    datagram.WriteTo(writer);
+                    ((IIonValue)datagram).WriteTo(writer);
                     writer.Finish();
                     var bin = ms.ToArray();
                     var catalog = Symbols.GetReaderCatalog(readerTable);
@@ -266,7 +266,7 @@ namespace IonDotnet.Tests.Integration
             }
         }
 
-        private static bool AssertDatagramEquivalent(IIonValue d1, IIonValue d2)
+        private static bool AssertDatagramEquivalent(IIonDatagram d1, IIonDatagram d2)
         {
             IonValue[] values1 = GetIonValues(d1);
             IonValue[] values2 = GetIonValues(d2);
@@ -275,7 +275,7 @@ namespace IonDotnet.Tests.Integration
             return eq;
         }
 
-        private static IonValue[] GetIonValues(IIonValue value)
+        private static IonValue[] GetIonValues(IIonDatagram value)
         {
             if (value is null)
                 return new IonValue[0];
@@ -290,7 +290,7 @@ namespace IonDotnet.Tests.Integration
             return ionValues;
         }
 
-        private static IIonValue LoadFile(FileInfo fi, out ISymbolTable readerTable)
+        private static IIonDatagram LoadFile(FileInfo fi, out ISymbolTable readerTable)
         {
             if (fi.Name == "utf16.ion")
             {
@@ -310,7 +310,7 @@ namespace IonDotnet.Tests.Integration
             return tree;
         }
 
-        private static IIonValue LoadFile(FileInfo fi) => LoadFile(fi, out _);
+        private static IIonDatagram LoadFile(FileInfo fi) => LoadFile(fi, out _);
 
         private class ValueComparer : IEqualityComparer<IonValue>
         {

--- a/IonDotnet.Tests/Integration/VectorBad.cs
+++ b/IonDotnet.Tests/Integration/VectorBad.cs
@@ -16,10 +16,7 @@ namespace IonDotnet.Tests.Integration
         {
             "shortUtf8Sequence_1.ion",
             "shortUtf8Sequence_2.ion",
-            "shortUtf8Sequence_3.ion",
-            "surrogate_6.ion",
-            "surrogate_7.ion",
-            "surrogate_8.ion"
+            "shortUtf8Sequence_3.ion"
         };
 
         private static readonly DirectoryInfo IonTestDir = DirStructure.IonTestDir();

--- a/IonDotnet.Tests/Internals/BinaryReaderTimestampTest.cs
+++ b/IonDotnet.Tests/Internals/BinaryReaderTimestampTest.cs
@@ -34,7 +34,7 @@ namespace IonDotnet.Tests.Internals
                 foreach (var ionValue in datagram)
                 {
                     Assert.IsTrue(ionValue is IonTimestamp);
-                    var ionTimestamp = (IonTimestamp)ionValue;
+                    var ionTimestamp = ionValue;
                     Assert.AreEqual(0.123 * TimeSpan.TicksPerSecond, ionTimestamp.TimestampValue.DateTimeValue.Ticks % TimeSpan.TicksPerSecond);
                 }
             }

--- a/IonDotnet.Tests/Internals/BinaryReaderTimestampTest.cs
+++ b/IonDotnet.Tests/Internals/BinaryReaderTimestampTest.cs
@@ -33,7 +33,7 @@ namespace IonDotnet.Tests.Internals
                 var dg = IonLoader.Default.Load(bytes);
                 Assert.IsTrue(dg[0] is IonTimestamp);
                 var ionTimestamp = (IonTimestamp) dg[0];
-                Assert.AreEqual(0.123 * TimeSpan.TicksPerSecond, ionTimestamp.Value.DateTimeValue.Ticks % TimeSpan.TicksPerSecond);
+                Assert.AreEqual(0.123 * TimeSpan.TicksPerSecond, ionTimestamp.TimestampValue.DateTimeValue.Ticks % TimeSpan.TicksPerSecond);
             }
         }
     }

--- a/IonDotnet.Tests/Internals/BinaryReaderTimestampTest.cs
+++ b/IonDotnet.Tests/Internals/BinaryReaderTimestampTest.cs
@@ -30,10 +30,13 @@ namespace IonDotnet.Tests.Internals
                 binWriter.WriteTimestamp(ts);
                 binWriter.Finish();
                 var bytes = memStream.ToArray();
-                var dg = IonLoader.Default.Load(bytes);
-                Assert.IsTrue(dg[0] is IonTimestamp);
-                var ionTimestamp = (IonTimestamp) dg[0];
-                Assert.AreEqual(0.123 * TimeSpan.TicksPerSecond, ionTimestamp.TimestampValue.DateTimeValue.Ticks % TimeSpan.TicksPerSecond);
+                var datagram = IonLoader.Default.Load(bytes);
+                foreach (var ionValue in datagram)
+                {
+                    Assert.IsTrue(ionValue is IonTimestamp);
+                    var ionTimestamp = (IonTimestamp)ionValue;
+                    Assert.AreEqual(0.123 * TimeSpan.TicksPerSecond, ionTimestamp.TimestampValue.DateTimeValue.Ticks % TimeSpan.TicksPerSecond);
+                }
             }
         }
     }

--- a/IonDotnet.Tests/Tree/IonBlobTest.cs
+++ b/IonDotnet.Tests/Tree/IonBlobTest.cs
@@ -13,12 +13,12 @@ namespace IonDotnet.Tests.Tree
             return new IonBlob(new byte[0]);
         }
 
-        protected override IIonLob MakeNullValue()
+        protected override IIonValue MakeNullValue()
         {
             return IonBlob.NewNull();
         }
 
-        protected override IIonLob MakeWithBytes(ReadOnlySpan<byte> bytes)
+        protected override IIonValue MakeWithBytes(ReadOnlySpan<byte> bytes)
         {
             return new IonBlob(bytes);
         }

--- a/IonDotnet.Tests/Tree/IonBoolTest.cs
+++ b/IonDotnet.Tests/Tree/IonBoolTest.cs
@@ -14,7 +14,7 @@ namespace IonDotnet.Tests.Tree
         public void Null()
         {
             var n = IonBool.NewNull();
-            Assert.AreEqual(IonType.Bool, n.Type);
+            Assert.AreEqual(IonType.Bool, n.Type());
             Assert.IsTrue(n.IsNull);
             Assert.ThrowsException<NullValueException>(() => n.BoolValue);
         }
@@ -25,7 +25,7 @@ namespace IonDotnet.Tests.Tree
         public void SimpleValue(bool value)
         {
             var v = new IonBool(value);
-            Assert.AreEqual(IonType.Bool, v.Type);
+            Assert.AreEqual(IonType.Bool, v.Type());
             Assert.IsFalse(v.IsNull);
             Assert.AreEqual(value, v.BoolValue);
             v.BoolValue = !value;

--- a/IonDotnet.Tests/Tree/IonBoolTest.cs
+++ b/IonDotnet.Tests/Tree/IonBoolTest.cs
@@ -16,7 +16,7 @@ namespace IonDotnet.Tests.Tree
             var n = IonBool.NewNull();
             Assert.AreEqual(IonType.Bool, n.Type);
             Assert.IsTrue(n.IsNull);
-            Assert.ThrowsException<NullValueException>(() => n.Value);
+            Assert.ThrowsException<NullValueException>(() => n.BoolValue);
         }
 
         [TestMethod]
@@ -27,9 +27,9 @@ namespace IonDotnet.Tests.Tree
             var v = new IonBool(value);
             Assert.AreEqual(IonType.Bool, v.Type);
             Assert.IsFalse(v.IsNull);
-            Assert.AreEqual(value, v.Value);
-            v.Value = !value;
-            Assert.AreEqual(!value, v.Value);
+            Assert.AreEqual(value, v.BoolValue);
+            v.BoolValue = !value;
+            Assert.AreEqual(!value, v.BoolValue);
         }
 
         [DataRow(true)]
@@ -42,7 +42,7 @@ namespace IonDotnet.Tests.Tree
             Assert.IsFalse(v.IsReadOnly);
             v.MakeReadOnly();
             Assert.IsTrue(v.IsReadOnly);
-            Assert.ThrowsException<InvalidOperationException>(() => v.Value = value != true);
+            Assert.ThrowsException<InvalidOperationException>(() => v.BoolValue = value != true);
             Assert.ThrowsException<InvalidOperationException>(() => v.AddTypeAnnotation("something"));
             Assert.ThrowsException<InvalidOperationException>(() => v.MakeNull());
         }

--- a/IonDotnet.Tests/Tree/IonClobTest.cs
+++ b/IonDotnet.Tests/Tree/IonClobTest.cs
@@ -20,12 +20,12 @@ namespace IonDotnet.Tests.Tree
             return new IonClob(new byte[0]);
         }
 
-        protected override IIonLob MakeNullValue()
+        protected override IIonValue MakeNullValue()
         {
             return IonClob.NewNull();
         }
 
-        protected override IIonLob MakeWithBytes(ReadOnlySpan<byte> bytes)
+        protected override IIonValue MakeWithBytes(ReadOnlySpan<byte> bytes)
         {
             return new IonClob(bytes);
         }

--- a/IonDotnet.Tests/Tree/IonContainerTest.cs
+++ b/IonDotnet.Tests/Tree/IonContainerTest.cs
@@ -23,7 +23,7 @@ namespace IonDotnet.Tests.Tree
         {
             var v = (IonValue) MakeMutableValue();
             var n = MakeNullValue();
-            Assert.AreEqual(v.Type, n.Type);
+            Assert.AreEqual(v.Type(), n.Type());
             Assert.IsTrue(n.IsNull);
             Assert.AreEqual(0, n.Count);
             Assert.IsFalse(v.IsNull);

--- a/IonDotnet.Tests/Tree/IonFloatTest.cs
+++ b/IonDotnet.Tests/Tree/IonFloatTest.cs
@@ -17,7 +17,7 @@ namespace IonDotnet.Tests.Tree
         public void Null()
         {
             var n = IonFloat.NewNull();
-            Assert.AreEqual(IonType.Float, n.Type);
+            Assert.AreEqual(IonType.Float, n.Type());
             Assert.IsTrue(n.IsNull);
             Assert.ThrowsException<NullValueException>(() => n.FloatValue);
         }
@@ -29,7 +29,7 @@ namespace IonDotnet.Tests.Tree
         public void SimpleValueTest(double value)
         {
             var v = new IonFloat(value);
-            Assert.AreEqual(IonType.Float, v.Type);
+            Assert.AreEqual(IonType.Float, v.Type());
             Assert.IsFalse(v.IsNull);
             Assert.AreEqual(value, v.FloatValue);
 

--- a/IonDotnet.Tests/Tree/IonFloatTest.cs
+++ b/IonDotnet.Tests/Tree/IonFloatTest.cs
@@ -19,7 +19,7 @@ namespace IonDotnet.Tests.Tree
             var n = IonFloat.NewNull();
             Assert.AreEqual(IonType.Float, n.Type);
             Assert.IsTrue(n.IsNull);
-            Assert.ThrowsException<NullValueException>(() => n.Value);
+            Assert.ThrowsException<NullValueException>(() => n.FloatValue);
         }
 
         [DataRow(0.0)]
@@ -31,10 +31,10 @@ namespace IonDotnet.Tests.Tree
             var v = new IonFloat(value);
             Assert.AreEqual(IonType.Float, v.Type);
             Assert.IsFalse(v.IsNull);
-            Assert.AreEqual(value, v.Value);
+            Assert.AreEqual(value, v.FloatValue);
 
-            v.Value = 1.0 + value;
-            Assert.AreEqual(1.0 + value, v.Value);
+            v.FloatValue = 1.0 + value;
+            Assert.AreEqual(1.0 + value, v.FloatValue);
         }
 
         [DataRow(null)]
@@ -48,7 +48,7 @@ namespace IonDotnet.Tests.Tree
             Assert.IsFalse(v.IsReadOnly);
             v.MakeReadOnly();
             Assert.IsTrue(v.IsReadOnly);
-            Assert.ThrowsException<InvalidOperationException>(() => v.Value = 0.5);
+            Assert.ThrowsException<InvalidOperationException>(() => v.FloatValue = 0.5);
             Assert.ThrowsException<InvalidOperationException>(() => v.AddTypeAnnotation("something"));
             Assert.ThrowsException<InvalidOperationException>(() => v.MakeNull());
         }

--- a/IonDotnet.Tests/Tree/IonFloatTest.cs
+++ b/IonDotnet.Tests/Tree/IonFloatTest.cs
@@ -19,7 +19,7 @@ namespace IonDotnet.Tests.Tree
             var n = IonFloat.NewNull();
             Assert.AreEqual(IonType.Float, n.Type());
             Assert.IsTrue(n.IsNull);
-            Assert.ThrowsException<NullValueException>(() => n.FloatValue);
+            Assert.ThrowsException<NullValueException>(() => n.DoubleValue);
         }
 
         [DataRow(0.0)]
@@ -31,10 +31,10 @@ namespace IonDotnet.Tests.Tree
             var v = new IonFloat(value);
             Assert.AreEqual(IonType.Float, v.Type());
             Assert.IsFalse(v.IsNull);
-            Assert.AreEqual(value, v.FloatValue);
+            Assert.AreEqual(value, v.DoubleValue);
 
-            v.FloatValue = 1.0 + value;
-            Assert.AreEqual(1.0 + value, v.FloatValue);
+            v.DoubleValue = 1.0 + value;
+            Assert.AreEqual(1.0 + value, v.DoubleValue);
         }
 
         [DataRow(null)]
@@ -48,7 +48,7 @@ namespace IonDotnet.Tests.Tree
             Assert.IsFalse(v.IsReadOnly);
             v.MakeReadOnly();
             Assert.IsTrue(v.IsReadOnly);
-            Assert.ThrowsException<InvalidOperationException>(() => v.FloatValue = 0.5);
+            Assert.ThrowsException<InvalidOperationException>(() => v.DoubleValue = 0.5);
             Assert.ThrowsException<InvalidOperationException>(() => v.AddTypeAnnotation("something"));
             Assert.ThrowsException<InvalidOperationException>(() => v.MakeNull());
         }

--- a/IonDotnet.Tests/Tree/IonIntTest.cs
+++ b/IonDotnet.Tests/Tree/IonIntTest.cs
@@ -15,7 +15,7 @@ namespace IonDotnet.Tests.Tree
         public void Null()
         {
             var n = IonInt.NewNull();
-            Assert.AreEqual(IonType.Int, n.Type);
+            Assert.AreEqual(IonType.Int, n.Type());
             Assert.IsTrue(n.IsNull);
             Assert.AreEqual(IntegerSize.Unknown, n.IntegerSize);
             Assert.ThrowsException<NullValueException>(() => n.IntValue);

--- a/IonDotnet.Tests/Tree/IonLobTest.cs
+++ b/IonDotnet.Tests/Tree/IonLobTest.cs
@@ -9,9 +9,9 @@ namespace IonDotnet.Tests.Tree
 {
     public abstract class IonLobTest : TreeTestBase
     {
-        protected abstract IIonLob MakeNullValue();
+        protected abstract IIonValue MakeNullValue();
 
-        protected abstract IIonLob MakeWithBytes(ReadOnlySpan<byte> bytes);
+        protected abstract IIonValue MakeWithBytes(ReadOnlySpan<byte> bytes);
 
         protected abstract IonType MainIonType { get; }
 
@@ -20,7 +20,7 @@ namespace IonDotnet.Tests.Tree
         {
             var n = MakeNullValue();
             Assert.IsTrue(n.IsNull);
-            Assert.AreEqual(MainIonType, n.Type);
+            Assert.AreEqual(MainIonType, n.Type());
             Assert.ThrowsException<NullValueException>(() => n.Bytes());
             if (n is IonClob nclob)
             {
@@ -33,7 +33,7 @@ namespace IonDotnet.Tests.Tree
         {
             var bytes = Enumerable.Repeat<byte>(1, 10).ToArray();
             var v = MakeWithBytes(bytes);
-            Assert.AreEqual(MainIonType, v.Type);
+            Assert.AreEqual(MainIonType, v.Type());
             Assert.IsFalse(v.IsNull);
             Assert.IsTrue(v.Bytes().SequenceEqual(bytes));
             bytes[0] = 2;

--- a/IonDotnet.Tests/Tree/IonStringTest.cs
+++ b/IonDotnet.Tests/Tree/IonStringTest.cs
@@ -14,7 +14,7 @@ namespace IonDotnet.Tests.Tree
         public void Null()
         {
             var n = new IonString(null);
-            Assert.AreEqual(IonType.String, n.Type);
+            Assert.AreEqual(IonType.String, n.Type());
             Assert.IsTrue(n.IsNull);
             Assert.IsNull(n.StringValue);
         }
@@ -26,7 +26,7 @@ namespace IonDotnet.Tests.Tree
         public void SimpleValue(string value, string value2)
         {
             var v = new IonString(value);
-            Assert.AreEqual(IonType.String, v.Type);
+            Assert.AreEqual(IonType.String, v.Type());
             Assert.IsFalse(v.IsNull);
             Assert.AreEqual(value, v.StringValue);
 

--- a/IonDotnet.Tests/Tree/IonStructTest.cs
+++ b/IonDotnet.Tests/Tree/IonStructTest.cs
@@ -91,7 +91,7 @@ namespace IonDotnet.Tests.Tree
             Assert.AreEqual(2, v.Count);
             Assert.AreEqual(1, v.Count(val => val.FieldNameSymbol.Text == fieldName));
             var ionBool = (IonBool) v[fieldName];
-            Assert.IsFalse(ionBool.Value);
+            Assert.IsFalse(ionBool.BoolValue);
         }
 
         [TestMethod]

--- a/IonDotnet/Builders/IonLoader.cs
+++ b/IonDotnet/Builders/IonLoader.cs
@@ -28,8 +28,8 @@ namespace IonDotnet.Builders
         /// Load a string of Ion text.
         /// </summary>
         /// <param name="ionText">Ion text string.</param>
-        /// <returns>An <see cref="IIonDatagram"/> tree view.</returns>
-        public IIonDatagram Load(string ionText)
+        /// <returns>An <see cref="IIonValue"/> tree view, which is an instance of IIonDatagram</returns>
+        public IIonValue Load(string ionText)
         {
             var reader = IonReaderBuilder.Build(ionText, _readerOptions);
             return WriteDatagram(reader);
@@ -40,8 +40,8 @@ namespace IonDotnet.Builders
         /// </summary>
         /// <param name="ionText">Ion text string.</param>
         /// <param name="readerTable">Reader's local symbol table.</param>
-        /// <returns>An <see cref="IIonDatagram"/> tree view.</returns>
-        public IIonDatagram Load(string ionText, out ISymbolTable readerTable)
+        /// <returns>An <see cref="IIonValue"/> tree view, which is an instance of IIonDatagram</returns>
+        public IIonValue Load(string ionText, out ISymbolTable readerTable)
         {
             var reader = IonReaderBuilder.Build(ionText, _readerOptions);
             var dg = WriteDatagram(reader);
@@ -49,24 +49,35 @@ namespace IonDotnet.Builders
             return dg;
         }
 
-//        /// <summary>
-//        /// Load Ion data from a byte buffer. Detecting whether it's binary or Unicode text Ion.
-//        /// </summary>
-//        /// <param name="data">Byte buffer.</param>
-//        /// <returns>An <see cref="IonDatagram"/> tree view.</returns>
-//        public IonDatagram Load(Span<byte> data)
-//        {
-//            throw new NotImplementedException();
-//        }
+        //        /// <summary>
+        //        /// Load Ion data from a byte buffer. Detecting whether it's binary or Unicode text Ion.
+        //        /// </summary>
+        //        /// <param name="data">Byte buffer.</param>
+        //        /// <returns>An <see cref="IonDatagram"/> tree view.</returns>
+        //        public IonDatagram Load(Span<byte> data)
+        //        {
+        //            throw new NotImplementedException();
+        //        }
 
-        public IIonDatagram Load(Stream stream)
+        /// <summary>
+        /// Load Ion data from stream.
+        /// </summary>
+        /// <param name="stream">Stream</param>
+        /// <returns>An <see cref="IIonValue"/> tree view, which is an instance of IIonDatagram</returns>
+        public IIonValue Load(Stream stream)
         {
             var reader = IonReaderBuilder.Build(stream, _readerOptions);
             var dg = WriteDatagram(reader);
             return dg;
         }
 
-        public IIonDatagram Load(Stream stream, out ISymbolTable readerTable)
+        /// <summary>
+        /// Load Ion data from stream.
+        /// </summary>
+        /// <param name="stream">Stream</param>
+        /// <param name="readerTable">Reader's local symbol table.</param>
+        /// <returns>An <see cref="IIonValue"/> tree view, which is an instance of IIonDatagram</returns>
+        public IIonValue Load(Stream stream, out ISymbolTable readerTable)
         {
             var reader = IonReaderBuilder.Build(stream, _readerOptions);
             var dg = WriteDatagram(reader);
@@ -78,8 +89,8 @@ namespace IonDotnet.Builders
         /// Load Ion data from a file. Detecting whether it's binary or Unicode text Ion.
         /// </summary>
         /// <param name="ionFile">Ion file.</param>
-        /// <returns>An <see cref="IIonDatagram"/> tree view.</returns>
-        public IIonDatagram Load(FileInfo ionFile)
+        /// <returns>An <see cref="IIonValue"/> tree view, which is an instance of IIonDatagram</returns>
+        public IIonValue Load(FileInfo ionFile)
         {
             if (!ionFile.Exists)
             {
@@ -98,8 +109,8 @@ namespace IonDotnet.Builders
         /// </summary>
         /// <param name="ionFile">Ion file.</param>
         /// <param name="readerTable">The local table used by the reader.</param>
-        /// <returns>An <see cref="IIonDatagram"/> tree view.</returns>
-        public IIonDatagram Load(FileInfo ionFile, out ISymbolTable readerTable)
+        /// <returns>An <see cref="IIonValue"/> tree view, which is an instance of IIonDatagram</returns>
+        public IIonValue Load(FileInfo ionFile, out ISymbolTable readerTable)
         {
             using (var stream = ionFile.OpenRead())
             {
@@ -112,8 +123,8 @@ namespace IonDotnet.Builders
         /// Load Ion data from a byte array.
         /// </summary>
         /// <param name="data">Ion data.</param>
-        /// <returns>An <see cref="IIonDatagram"/> tree view.</returns>
-        public IIonDatagram Load(byte[] data)
+        /// <returns>An <see cref="IIonValue"/> tree view, which is an instance of IIonDatagram</returns>
+        public IIonValue Load(byte[] data)
         {
             using (var stream = new MemoryStream(data))
             {
@@ -127,8 +138,8 @@ namespace IonDotnet.Builders
         /// </summary>
         /// <param name="data">Ion data.</param>
         /// <param name="readerTable">The local table used by the reader.</param>
-        /// <returns>An <see cref="IIonDatagram"/> tree view.</returns>
-        public IIonDatagram Load(byte[] data, out ISymbolTable readerTable)
+        /// <returns>An <see cref="IIonValue"/> tree view, which is an instance of IIonDatagram</returns>
+        public IIonValue Load(byte[] data, out ISymbolTable readerTable)
         {
             using (var stream = new MemoryStream(data))
             {

--- a/IonDotnet/Builders/IonLoader.cs
+++ b/IonDotnet/Builders/IonLoader.cs
@@ -1,7 +1,6 @@
 using System.IO;
-using System.Text;
 using IonDotnet.Internals;
-using IonDotnet.Internals.Text;
+using IonDotnet.Tree;
 using IonDotnet.Tree.Impl;
 
 namespace IonDotnet.Builders
@@ -29,8 +28,8 @@ namespace IonDotnet.Builders
         /// Load a string of Ion text.
         /// </summary>
         /// <param name="ionText">Ion text string.</param>
-        /// <returns>An <see cref="IonDatagram"/> tree view.</returns>
-        internal IonDatagram Load(string ionText)
+        /// <returns>An <see cref="IIonValue"/> tree view.</returns>
+        public IIonValue Load(string ionText)
         {
             var reader = IonReaderBuilder.Build(ionText, _readerOptions);
             return WriteDatagram(reader);
@@ -41,8 +40,8 @@ namespace IonDotnet.Builders
         /// </summary>
         /// <param name="ionText">Ion text string.</param>
         /// <param name="readerTable">Reader's local symbol table.</param>
-        /// <returns>An <see cref="IonDatagram"/> tree view.</returns>
-        internal IonDatagram Load(string ionText, out ISymbolTable readerTable)
+        /// <returns>An <see cref="IIonValue"/> tree view.</returns>
+        public IIonValue Load(string ionText, out ISymbolTable readerTable)
         {
             var reader = IonReaderBuilder.Build(ionText, _readerOptions);
             var dg = WriteDatagram(reader);
@@ -60,14 +59,14 @@ namespace IonDotnet.Builders
 //            throw new NotImplementedException();
 //        }
 
-        internal IonDatagram Load(Stream stream)
+        public IIonValue Load(Stream stream)
         {
             var reader = IonReaderBuilder.Build(stream, _readerOptions);
             var dg = WriteDatagram(reader);
             return dg;
         }
 
-        internal IonDatagram Load(Stream stream, out ISymbolTable readerTable)
+        public IIonValue Load(Stream stream, out ISymbolTable readerTable)
         {
             var reader = IonReaderBuilder.Build(stream, _readerOptions);
             var dg = WriteDatagram(reader);
@@ -79,8 +78,8 @@ namespace IonDotnet.Builders
         /// Load Ion data from a file. Detecting whether it's binary or Unicode text Ion.
         /// </summary>
         /// <param name="ionFile">Ion file.</param>
-        /// <returns>An <see cref="IonDatagram"/> tree view.</returns>
-        internal IonDatagram Load(FileInfo ionFile)
+        /// <returns>An <see cref="IIonValue"/> tree view.</returns>
+        public IIonValue Load(FileInfo ionFile)
         {
             if (!ionFile.Exists)
             {
@@ -99,8 +98,8 @@ namespace IonDotnet.Builders
         /// </summary>
         /// <param name="ionFile">Ion file.</param>
         /// <param name="readerTable">The local table used by the reader.</param>
-        /// <returns>An <see cref="IonDatagram"/> tree view.</returns>
-        internal IonDatagram Load(FileInfo ionFile, out ISymbolTable readerTable)
+        /// <returns>An <see cref="IIonValue"/> tree view.</returns>
+        public IIonValue Load(FileInfo ionFile, out ISymbolTable readerTable)
         {
             using (var stream = ionFile.OpenRead())
             {
@@ -113,8 +112,8 @@ namespace IonDotnet.Builders
         /// Load Ion data from a byte array.
         /// </summary>
         /// <param name="data">Ion data.</param>
-        /// <returns>An <see cref="IonDatagram"/> tree view.</returns>
-        internal IonDatagram Load(byte[] data)
+        /// <returns>An <see cref="IIonValue"/> tree view.</returns>
+        public IIonValue Load(byte[] data)
         {
             using (var stream = new MemoryStream(data))
             {
@@ -128,8 +127,8 @@ namespace IonDotnet.Builders
         /// </summary>
         /// <param name="data">Ion data.</param>
         /// <param name="readerTable">The local table used by the reader.</param>
-        /// <returns>An <see cref="IonDatagram"/> tree view.</returns>
-        internal IonDatagram Load(byte[] data, out ISymbolTable readerTable)
+        /// <returns>An <see cref="IIonValue"/> tree view.</returns>
+        public IIonValue Load(byte[] data, out ISymbolTable readerTable)
         {
             using (var stream = new MemoryStream(data))
             {
@@ -138,7 +137,7 @@ namespace IonDotnet.Builders
             }
         }
 
-        private static IonDatagram WriteDatagram(IIonReader reader)
+        private static IIonValue WriteDatagram(IIonReader reader)
         {
             var datagram = new IonDatagram();
             var writer = new IonTreeWriter(datagram);

--- a/IonDotnet/Builders/IonLoader.cs
+++ b/IonDotnet/Builders/IonLoader.cs
@@ -29,7 +29,7 @@ namespace IonDotnet.Builders
         /// </summary>
         /// <param name="ionText">Ion text string.</param>
         /// <returns>An <see cref="IIonValue"/> tree view.</returns>
-        public IIonValue Load(string ionText)
+        public IIonDatagram Load(string ionText)
         {
             var reader = IonReaderBuilder.Build(ionText, _readerOptions);
             return WriteDatagram(reader);
@@ -41,7 +41,7 @@ namespace IonDotnet.Builders
         /// <param name="ionText">Ion text string.</param>
         /// <param name="readerTable">Reader's local symbol table.</param>
         /// <returns>An <see cref="IIonValue"/> tree view.</returns>
-        public IIonValue Load(string ionText, out ISymbolTable readerTable)
+        public IIonDatagram Load(string ionText, out ISymbolTable readerTable)
         {
             var reader = IonReaderBuilder.Build(ionText, _readerOptions);
             var dg = WriteDatagram(reader);
@@ -59,14 +59,14 @@ namespace IonDotnet.Builders
 //            throw new NotImplementedException();
 //        }
 
-        public IIonValue Load(Stream stream)
+        public IIonDatagram Load(Stream stream)
         {
             var reader = IonReaderBuilder.Build(stream, _readerOptions);
             var dg = WriteDatagram(reader);
             return dg;
         }
 
-        public IIonValue Load(Stream stream, out ISymbolTable readerTable)
+        public IIonDatagram Load(Stream stream, out ISymbolTable readerTable)
         {
             var reader = IonReaderBuilder.Build(stream, _readerOptions);
             var dg = WriteDatagram(reader);
@@ -79,7 +79,7 @@ namespace IonDotnet.Builders
         /// </summary>
         /// <param name="ionFile">Ion file.</param>
         /// <returns>An <see cref="IIonValue"/> tree view.</returns>
-        public IIonValue Load(FileInfo ionFile)
+        public IIonDatagram Load(FileInfo ionFile)
         {
             if (!ionFile.Exists)
             {
@@ -99,7 +99,7 @@ namespace IonDotnet.Builders
         /// <param name="ionFile">Ion file.</param>
         /// <param name="readerTable">The local table used by the reader.</param>
         /// <returns>An <see cref="IIonValue"/> tree view.</returns>
-        public IIonValue Load(FileInfo ionFile, out ISymbolTable readerTable)
+        public IIonDatagram Load(FileInfo ionFile, out ISymbolTable readerTable)
         {
             using (var stream = ionFile.OpenRead())
             {
@@ -113,7 +113,7 @@ namespace IonDotnet.Builders
         /// </summary>
         /// <param name="data">Ion data.</param>
         /// <returns>An <see cref="IIonValue"/> tree view.</returns>
-        public IIonValue Load(byte[] data)
+        public IIonDatagram Load(byte[] data)
         {
             using (var stream = new MemoryStream(data))
             {
@@ -128,7 +128,7 @@ namespace IonDotnet.Builders
         /// <param name="data">Ion data.</param>
         /// <param name="readerTable">The local table used by the reader.</param>
         /// <returns>An <see cref="IIonValue"/> tree view.</returns>
-        public IIonValue Load(byte[] data, out ISymbolTable readerTable)
+        public IIonDatagram Load(byte[] data, out ISymbolTable readerTable)
         {
             using (var stream = new MemoryStream(data))
             {

--- a/IonDotnet/Builders/IonLoader.cs
+++ b/IonDotnet/Builders/IonLoader.cs
@@ -28,7 +28,7 @@ namespace IonDotnet.Builders
         /// Load a string of Ion text.
         /// </summary>
         /// <param name="ionText">Ion text string.</param>
-        /// <returns>An <see cref="IIonValue"/> tree view.</returns>
+        /// <returns>An <see cref="IIonDatagram"/> tree view.</returns>
         public IIonDatagram Load(string ionText)
         {
             var reader = IonReaderBuilder.Build(ionText, _readerOptions);
@@ -40,7 +40,7 @@ namespace IonDotnet.Builders
         /// </summary>
         /// <param name="ionText">Ion text string.</param>
         /// <param name="readerTable">Reader's local symbol table.</param>
-        /// <returns>An <see cref="IIonValue"/> tree view.</returns>
+        /// <returns>An <see cref="IIonDatagram"/> tree view.</returns>
         public IIonDatagram Load(string ionText, out ISymbolTable readerTable)
         {
             var reader = IonReaderBuilder.Build(ionText, _readerOptions);
@@ -78,7 +78,7 @@ namespace IonDotnet.Builders
         /// Load Ion data from a file. Detecting whether it's binary or Unicode text Ion.
         /// </summary>
         /// <param name="ionFile">Ion file.</param>
-        /// <returns>An <see cref="IIonValue"/> tree view.</returns>
+        /// <returns>An <see cref="IIonDatagram"/> tree view.</returns>
         public IIonDatagram Load(FileInfo ionFile)
         {
             if (!ionFile.Exists)
@@ -98,7 +98,7 @@ namespace IonDotnet.Builders
         /// </summary>
         /// <param name="ionFile">Ion file.</param>
         /// <param name="readerTable">The local table used by the reader.</param>
-        /// <returns>An <see cref="IIonValue"/> tree view.</returns>
+        /// <returns>An <see cref="IIonDatagram"/> tree view.</returns>
         public IIonDatagram Load(FileInfo ionFile, out ISymbolTable readerTable)
         {
             using (var stream = ionFile.OpenRead())
@@ -112,7 +112,7 @@ namespace IonDotnet.Builders
         /// Load Ion data from a byte array.
         /// </summary>
         /// <param name="data">Ion data.</param>
-        /// <returns>An <see cref="IIonValue"/> tree view.</returns>
+        /// <returns>An <see cref="IIonDatagram"/> tree view.</returns>
         public IIonDatagram Load(byte[] data)
         {
             using (var stream = new MemoryStream(data))
@@ -127,7 +127,7 @@ namespace IonDotnet.Builders
         /// </summary>
         /// <param name="data">Ion data.</param>
         /// <param name="readerTable">The local table used by the reader.</param>
-        /// <returns>An <see cref="IIonValue"/> tree view.</returns>
+        /// <returns>An <see cref="IIonDatagram"/> tree view.</returns>
         public IIonDatagram Load(byte[] data, out ISymbolTable readerTable)
         {
             using (var stream = new MemoryStream(data))

--- a/IonDotnet/ContainedValueException.cs
+++ b/IonDotnet/ContainedValueException.cs
@@ -1,4 +1,4 @@
-﻿using IonDotnet.Tree.Impl;
+﻿using IonDotnet.Tree;
 
 namespace IonDotnet
 {
@@ -8,7 +8,7 @@ namespace IonDotnet
         {
         }
 
-        internal ContainedValueException(IonValue value) : this(value.ToString())
+        internal ContainedValueException(IIonValue value) : this(value.ToString())
         {
         }
 

--- a/IonDotnet/Internals/IonTreeWriter.cs
+++ b/IonDotnet/Internals/IonTreeWriter.cs
@@ -1,13 +1,14 @@
 using System;
 using System.Diagnostics;
 using System.Numerics;
+using IonDotnet.Tree;
 using IonDotnet.Tree.Impl;
 
 namespace IonDotnet.Internals
 {
     internal class IonTreeWriter : IonSystemWriter
     {
-        private IonContainer _currentContainer;
+        private IIonContainer _currentContainer;
 
         public IonTreeWriter(IonContainer root)
         {
@@ -176,7 +177,7 @@ namespace IonDotnet.Internals
             _currentContainer = _currentContainer.Container;
         }
 
-        public override bool IsInStruct => _currentContainer.Type == IonType.Struct;
+        public override bool IsInStruct => ((IIonValue)_currentContainer).Type() == IonType.Struct;
 
         public override int GetDepth()
         {

--- a/IonDotnet/Internals/Text/TextScanner.cs
+++ b/IonDotnet/Internals/Text/TextScanner.cs
@@ -1029,11 +1029,17 @@ namespace IonDotnet.Internals.Text
                         //                        break;
                 }
 
-                if (!isClob && char.IsHighSurrogate((char)c))
-                {
-                    sb.Append((char)c);
-                    c = ReadChar();
-                    if (!char.IsLowSurrogate((char)c))
+                if (!isClob) {
+                    if (char.IsHighSurrogate((char)c))
+                    {
+                        sb.Append((char)c);
+                        c = ReadChar();
+                        if (!char.IsLowSurrogate((char)c))
+                        {
+                            throw new IonException($"Invalid character format {(char)c}");
+                        }
+                    }
+                    else if (char.IsLowSurrogate((char)c))
                     {
                         throw new IonException($"Invalid character format {(char)c}");
                     }
@@ -1125,6 +1131,10 @@ namespace IonDotnet.Internals.Text
                         {
                             throw new IonException($"Invalid character format {(char)c}");
                         }
+                    }
+                    else if (char.IsLowSurrogate((char)c))
+                    {
+                        throw new IonException($"Invalid character format {(char)c}");
                     }
                 }
                 else if (Characters.Is8BitChar(c))
@@ -2005,7 +2015,10 @@ namespace IonDotnet.Internals.Text
                             throw new IonException($"Invalid character format {(char)c}");
                         }
                     }
-
+                    else if (char.IsLowSurrogate((char)c))
+                    {
+                        throw new IonException($"Invalid character format {(char)c}");
+                    }
                     //                    sb.Append(c);
                     //
                     //                    if (Characters.NeedsSurrogateEncoding(c))

--- a/IonDotnet/IonType.cs
+++ b/IonDotnet/IonType.cs
@@ -48,7 +48,7 @@
         /// </summary>
         /// <param name="t">IonType enum</param>
         /// <returns>true when the this is a scalar type</returns>
-        public static bool IsScalar(this IonType t) => t > IonType.None && t < IonType.Clob;
+        public static bool IsScalar(this IonType t) => t > IonType.None && t < IonType.List;
 
         /// <summary>
         /// Determines whether a type represents a numeric type

--- a/IonDotnet/Tree/IIonBool.cs
+++ b/IonDotnet/Tree/IIonBool.cs
@@ -1,7 +1,7 @@
 ﻿namespace IonDotnet.Tree
 {
-    public interface IIonBool : IIonValue
+    public interface IIonBool
     {
-        bool Value { get; set; }
+        bool BoolValue { get; set; }
     }
 }

--- a/IonDotnet/Tree/IIonContainer.cs
+++ b/IonDotnet/Tree/IIonContainer.cs
@@ -1,8 +1,16 @@
-﻿namespace IonDotnet.Tree
+﻿using System.Collections.Generic;
+
+namespace IonDotnet.Tree
 {
     public interface IIonContainer
     {
         int Count { get; }
         void Clear();
+        void Add(IIonValue item);
+        bool Remove(IIonValue item);
+        bool Contains(IIonValue item);
+        void CopyTo(IIonValue[] array, int arrayIndex);
+        IEnumerator<IIonValue> GetEnumerator();
+        IIonContainer Container { get; set; }
     }
 }

--- a/IonDotnet/Tree/IIonContainer.cs
+++ b/IonDotnet/Tree/IIonContainer.cs
@@ -1,7 +1,8 @@
 ﻿namespace IonDotnet.Tree
 {
-    public interface IIonContainer : IIonValue
+    public interface IIonContainer
     {
         int Count { get; }
+        void Clear();
     }
 }

--- a/IonDotnet/Tree/IIonContainer.cs
+++ b/IonDotnet/Tree/IIonContainer.cs
@@ -4,13 +4,13 @@ namespace IonDotnet.Tree
 {
     public interface IIonContainer
     {
+        IIonContainer Container { get; set; }
         int Count { get; }
-        void Clear();
         void Add(IIonValue item);
-        bool Remove(IIonValue item);
+        void Clear();
         bool Contains(IIonValue item);
         void CopyTo(IIonValue[] array, int arrayIndex);
         IEnumerator<IIonValue> GetEnumerator();
-        IIonContainer Container { get; set; }
+        bool Remove(IIonValue item);
     }
 }

--- a/IonDotnet/Tree/IIonDatagram.cs
+++ b/IonDotnet/Tree/IIonDatagram.cs
@@ -2,5 +2,6 @@
 {
     public interface IIonDatagram : IIonSequence
     {
+        void WriteTo(IIonWriter writer);
     }
 }

--- a/IonDotnet/Tree/IIonDatagram.cs
+++ b/IonDotnet/Tree/IIonDatagram.cs
@@ -2,6 +2,5 @@
 {
     public interface IIonDatagram : IIonSequence
     {
-        void WriteTo(IIonWriter writer);
     }
 }

--- a/IonDotnet/Tree/IIonDecimal.cs
+++ b/IonDotnet/Tree/IIonDecimal.cs
@@ -1,6 +1,6 @@
 ﻿namespace IonDotnet.Tree
 {
-    public interface IIonDecimal : IIonValue
+    public interface IIonDecimal
     {
         decimal DecimalValue { get; set; }
         BigDecimal BigDecimalValue { get; set; }

--- a/IonDotnet/Tree/IIonFloat.cs
+++ b/IonDotnet/Tree/IIonFloat.cs
@@ -1,7 +1,7 @@
 ﻿namespace IonDotnet.Tree
 {
-    public interface IIonFloat : IIonValue
+    public interface IIonFloat
     {
-        double Value { get; set; }
+        double FloatValue { get; set; }
     }
 }

--- a/IonDotnet/Tree/IIonFloat.cs
+++ b/IonDotnet/Tree/IIonFloat.cs
@@ -2,6 +2,6 @@
 {
     public interface IIonFloat
     {
-        double FloatValue { get; set; }
+        double DoubleValue { get; set; }
     }
 }

--- a/IonDotnet/Tree/IIonInt.cs
+++ b/IonDotnet/Tree/IIonInt.cs
@@ -2,7 +2,7 @@
 
 namespace IonDotnet.Tree
 {
-    public interface IIonInt : IIonValue
+    public interface IIonInt
     {
         IntegerSize IntegerSize { get; }
         BigInteger BigIntegerValue { get; set; }

--- a/IonDotnet/Tree/IIonList.cs
+++ b/IonDotnet/Tree/IIonList.cs
@@ -1,6 +1,6 @@
 ﻿namespace IonDotnet.Tree
 {
-    public interface IIonList : IIonValue, IIonSequence
+    public interface IIonList : IIonSequence
     {
     }
 }

--- a/IonDotnet/Tree/IIonLob.cs
+++ b/IonDotnet/Tree/IIonLob.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 namespace IonDotnet.Tree
 {
-    public interface IIonLob : IIonValue
+    public interface IIonLob
     {
         ReadOnlySpan<byte> Bytes();
         void SetBytes(ReadOnlySpan<byte> buffer);
+        IonType Type { get; }
+        bool IsNull { get; }
     }
 }

--- a/IonDotnet/Tree/IIonLob.cs
+++ b/IonDotnet/Tree/IIonLob.cs
@@ -5,6 +5,5 @@ namespace IonDotnet.Tree
     {
         ReadOnlySpan<byte> Bytes();
         void SetBytes(ReadOnlySpan<byte> buffer);
-        bool IsNull { get; }
     }
 }

--- a/IonDotnet/Tree/IIonLob.cs
+++ b/IonDotnet/Tree/IIonLob.cs
@@ -5,7 +5,6 @@ namespace IonDotnet.Tree
     {
         ReadOnlySpan<byte> Bytes();
         void SetBytes(ReadOnlySpan<byte> buffer);
-        IonType Type { get; }
         bool IsNull { get; }
     }
 }

--- a/IonDotnet/Tree/IIonNull.cs
+++ b/IonDotnet/Tree/IIonNull.cs
@@ -1,6 +1,6 @@
 ﻿namespace IonDotnet.Tree
 {
-    public interface IIonNull : IIonValue
+    public interface IIonNull
     {
     }
 }

--- a/IonDotnet/Tree/IIonSequence.cs
+++ b/IonDotnet/Tree/IIonSequence.cs
@@ -3,5 +3,6 @@
     public interface IIonSequence : IIonContainer
     {
         void RemoveAt(int index);
+        int IndexOf(IIonValue item);
     }
 }

--- a/IonDotnet/Tree/IIonSequence.cs
+++ b/IonDotnet/Tree/IIonSequence.cs
@@ -4,5 +4,6 @@
     {
         void RemoveAt(int index);
         int IndexOf(IIonValue item);
+        IIonValue GetElementAt(int index);
     }
 }

--- a/IonDotnet/Tree/IIonSequence.cs
+++ b/IonDotnet/Tree/IIonSequence.cs
@@ -3,6 +3,5 @@
     public interface IIonSequence : IIonContainer
     {
         void RemoveAt(int index);
-        void Clear();
     }
 }

--- a/IonDotnet/Tree/IIonSexp.cs
+++ b/IonDotnet/Tree/IIonSexp.cs
@@ -1,6 +1,6 @@
 ﻿namespace IonDotnet.Tree
 {
-    public interface IIonSexp : IIonValue, IIonSequence
+    public interface IIonSexp : IIonSequence
     {
     }
 }

--- a/IonDotnet/Tree/IIonStruct.cs
+++ b/IonDotnet/Tree/IIonStruct.cs
@@ -2,7 +2,6 @@
 {
     public interface IIonStruct : IIonContainer
     {
-        void Clear();
         bool RemoveField(string fieldName);
         bool ContainsField(string fieldName);
     }

--- a/IonDotnet/Tree/IIonText.cs
+++ b/IonDotnet/Tree/IIonText.cs
@@ -1,6 +1,6 @@
 ﻿namespace IonDotnet.Tree
 {
-    public interface IIonText : IIonValue
+    public interface IIonText
     {
         string StringValue { get; set; }
     }

--- a/IonDotnet/Tree/IIonTimestamp.cs
+++ b/IonDotnet/Tree/IIonTimestamp.cs
@@ -1,7 +1,7 @@
 ﻿namespace IonDotnet.Tree
 {
-    public interface IIonTimestamp : IIonValue
+    public interface IIonTimestamp
     {
-        Timestamp Value { get; set; }
+        Timestamp TimestampValue { get; set; }
     }
 }

--- a/IonDotnet/Tree/IIonValue.cs
+++ b/IonDotnet/Tree/IIonValue.cs
@@ -7,15 +7,16 @@ namespace IonDotnet.Tree
         IIonBlob, IIonList, IIonSexp, IIonStruct, IIonDatagram
     {
         IReadOnlyCollection<SymbolToken> GetTypeAnnotations();
+        SymbolToken FieldNameSymbol { get; set; }
         bool HasAnnotation(string text);
         void AddTypeAnnotation(string annotation);
         void AddTypeAnnotation(SymbolToken annotation);
         void ClearAnnotations();
         void MakeReadOnly();
         string ToPrettyString();
-        void WriteTo(IIonWriter writer);
         bool IsEquivalentTo(IIonValue value);
         bool IsReadOnly { get; }
         void MakeNull();
+        IonType Type();
     }
 }

--- a/IonDotnet/Tree/IIonValue.cs
+++ b/IonDotnet/Tree/IIonValue.cs
@@ -6,19 +6,19 @@ namespace IonDotnet.Tree
         IIonDecimal, IIonTimestamp, IIonSymbol, IIonString, IIonClob,
         IIonBlob, IIonList, IIonSexp, IIonStruct, IIonDatagram
     {
-        IReadOnlyCollection<SymbolToken> GetTypeAnnotations();
         SymbolToken FieldNameSymbol { get; set; }
-        bool HasAnnotation(string text);
+        bool IsNull { get; }
+        bool IsReadOnly { get; }
         void AddTypeAnnotation(string annotation);
         void AddTypeAnnotation(SymbolToken annotation);
         void ClearAnnotations();
+        IReadOnlyCollection<SymbolToken> GetTypeAnnotations();
+        bool HasAnnotation(string text);
+        bool IsEquivalentTo(IIonValue value);
+        void MakeNull();
         void MakeReadOnly();
         string ToPrettyString();
-        void WriteTo(IIonWriter writer);
-        bool IsEquivalentTo(IIonValue value);
-        bool IsNull { get; }
-        bool IsReadOnly { get; }
-        void MakeNull();
         IonType Type();
+        void WriteTo(IIonWriter writer);
     }
 }

--- a/IonDotnet/Tree/IIonValue.cs
+++ b/IonDotnet/Tree/IIonValue.cs
@@ -14,7 +14,9 @@ namespace IonDotnet.Tree
         void ClearAnnotations();
         void MakeReadOnly();
         string ToPrettyString();
+        void WriteTo(IIonWriter writer);
         bool IsEquivalentTo(IIonValue value);
+        bool IsNull { get; }
         bool IsReadOnly { get; }
         void MakeNull();
         IonType Type();

--- a/IonDotnet/Tree/IIonValue.cs
+++ b/IonDotnet/Tree/IIonValue.cs
@@ -1,9 +1,10 @@
 ﻿using System.Collections.Generic;
-using IonDotnet.Tree.Impl;
 
 namespace IonDotnet.Tree
 {
-    public interface IIonValue
+    public interface IIonValue : IIonNull, IIonBool, IIonInt, IIonFloat,
+        IIonDecimal, IIonTimestamp, IIonSymbol, IIonString, IIonClob,
+        IIonBlob, IIonList, IIonSexp, IIonStruct, IIonDatagram
     {
         IReadOnlyCollection<SymbolToken> GetTypeAnnotations();
         bool HasAnnotation(string text);
@@ -14,9 +15,7 @@ namespace IonDotnet.Tree
         string ToPrettyString();
         void WriteTo(IIonWriter writer);
         bool IsEquivalentTo(IIonValue value);
-        IonType Type { get; }
         bool IsReadOnly { get; }
-        bool IsNull { get; }
         void MakeNull();
     }
 }

--- a/IonDotnet/Tree/Impl/IonBlob.cs
+++ b/IonDotnet/Tree/Impl/IonBlob.cs
@@ -22,7 +22,7 @@ namespace IonDotnet.Tree.Impl
         /// </summary>
         public static IonBlob NewNull() => new IonBlob();
 
-        public override bool IsEquivalentTo(IonValue other)
+        public override bool IsEquivalentTo(IIonValue other)
         {
             if (!base.IsEquivalentTo(other))
                 return false;
@@ -45,6 +45,6 @@ namespace IonDotnet.Tree.Impl
             writer.WriteBlob(Bytes());
         }
 
-        public override IonType Type => IonType.Blob;
+        public override IonType Type() => IonType.Blob;
     }
 }

--- a/IonDotnet/Tree/Impl/IonBool.cs
+++ b/IonDotnet/Tree/Impl/IonBool.cs
@@ -22,7 +22,7 @@ namespace IonDotnet.Tree.Impl
             if (NullFlagOn())
                 return otherBool.IsNull;
 
-            return !otherBool.IsNull && otherBool.Value == Value;
+            return !otherBool.IsNull && otherBool.BoolValue == BoolValue;
         }
 
         internal override void WriteBodyTo(IPrivateWriter writer)
@@ -39,7 +39,7 @@ namespace IonDotnet.Tree.Impl
 
         public override IonType Type => IonType.Bool;
 
-        public bool Value
+        public override bool BoolValue
         {
             get
             {

--- a/IonDotnet/Tree/Impl/IonBool.cs
+++ b/IonDotnet/Tree/Impl/IonBool.cs
@@ -12,7 +12,7 @@ namespace IonDotnet.Tree.Impl
             BoolTrueFlagOn(value);
         }
 
-        public override bool IsEquivalentTo(IonValue other)
+        public override bool IsEquivalentTo(IIonValue other)
         {
             if (!base.IsEquivalentTo(other))
                 return false;
@@ -37,7 +37,7 @@ namespace IonDotnet.Tree.Impl
             }
         }
 
-        public override IonType Type => IonType.Bool;
+        public override IonType Type() => IonType.Bool;
 
         public override bool BoolValue
         {

--- a/IonDotnet/Tree/Impl/IonClob.cs
+++ b/IonDotnet/Tree/Impl/IonClob.cs
@@ -53,7 +53,7 @@ namespace IonDotnet.Tree.Impl
         /// Returns a new <see cref="StreamReader"/> to read the content of this clob.
         /// </summary>
         /// <param name="encoding">Encoding to use.</param>
-        public StreamReader NewReader(Encoding encoding)
+        public override StreamReader NewReader(Encoding encoding)
         {
             ThrowIfNull();
             return new StreamReader(new MemoryStream(ByteBuffer), encoding);

--- a/IonDotnet/Tree/Impl/IonClob.cs
+++ b/IonDotnet/Tree/Impl/IonClob.cs
@@ -24,7 +24,7 @@ namespace IonDotnet.Tree.Impl
         /// </summary>
         public static IonClob NewNull() => new IonClob();
 
-        public override bool IsEquivalentTo(IonValue other)
+        public override bool IsEquivalentTo(IIonValue other)
         {
             if (!base.IsEquivalentTo(other))
                 return false;
@@ -47,7 +47,7 @@ namespace IonDotnet.Tree.Impl
             writer.WriteClob(Bytes());
         }
 
-        public override IonType Type => IonType.Clob;
+        public override IonType Type() => IonType.Clob;
 
         /// <summary>
         /// Returns a new <see cref="StreamReader"/> to read the content of this clob.

--- a/IonDotnet/Tree/Impl/IonContainer.cs
+++ b/IonDotnet/Tree/Impl/IonContainer.cs
@@ -9,7 +9,7 @@ namespace IonDotnet.Tree.Impl
     /// Base class for all container type (List,Struct,Sexp,Datagram) Ion values.
     /// This class also implements the <see cref="ICollection"/> interface.
     /// </summary>
-    internal abstract class IonContainer : IonValue, ICollection<IonValue>, IIonContainer
+    internal abstract class IonContainer : IonValue, ICollection<IIonValue>, IIonContainer
     {
         protected IonContainer(bool isNull) : base(isNull)
         {
@@ -20,7 +20,7 @@ namespace IonDotnet.Tree.Impl
         /// Add an Ion value to the container.
         /// </summary>
         /// <param name="item">Ion value.</param>
-        public abstract void Add(IonValue item);
+        public override abstract void Add(IIonValue item);
 
         /// <inheritdoc />
         /// <summary>
@@ -28,7 +28,7 @@ namespace IonDotnet.Tree.Impl
         /// </summary>
         /// <param name="item"></param>
         /// <returns>True if the item has been removed</returns>
-        public abstract bool Remove(IonValue item);
+        public override abstract bool Remove(IIonValue item);
 
 
         /// <inheritdoc />
@@ -52,14 +52,14 @@ namespace IonDotnet.Tree.Impl
         /// Returns true if the container contains an Ion value.
         /// </summary>
         /// <param name="item">Ion value.</param>
-        public abstract bool Contains(IonValue item);
+        public override abstract bool Contains(IIonValue item);
 
         /// <inheritdoc />
         /// <summary>
         /// This operation is not supported.
         /// </summary>
         /// <exception cref="NotSupportedException">This operation is not supported.</exception>
-        public void CopyTo(IonValue[] array, int arrayIndex) => throw new NotSupportedException();
+        public override void CopyTo(IIonValue[] array, int arrayIndex) => throw new NotSupportedException();
 
         public override void MakeNull()
         {
@@ -67,7 +67,7 @@ namespace IonDotnet.Tree.Impl
             base.MakeNull();
         }
 
-        public abstract IEnumerator<IonValue> GetEnumerator();
+        public override abstract IEnumerator<IIonValue> GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }

--- a/IonDotnet/Tree/Impl/IonContainer.cs
+++ b/IonDotnet/Tree/Impl/IonContainer.cs
@@ -35,7 +35,7 @@ namespace IonDotnet.Tree.Impl
         /// <summary>
         /// The number of children of this container.
         /// </summary>
-        public abstract int Count { get; }
+        public override abstract int Count { get; }
 
 
         /// <inheritdoc />
@@ -45,7 +45,7 @@ namespace IonDotnet.Tree.Impl
         /// <remarks>
         /// If this container is null, it will be set to a non-null empty container.
         /// </remarks>
-        public abstract void Clear();
+        public override abstract void Clear();
 
         /// <inheritdoc />
         /// <summary>

--- a/IonDotnet/Tree/Impl/IonDatagram.cs
+++ b/IonDotnet/Tree/Impl/IonDatagram.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace IonDotnet.Tree.Impl
@@ -18,23 +17,36 @@ namespace IonDotnet.Tree.Impl
         /// <summary>
         /// Use strict reference equality for datagram.
         /// </summary>
-        public override bool IsEquivalentTo(IonValue other) => other == this;
+        public override bool IsEquivalentTo(IIonValue other) => other == this;
 
-        public override IonType Type => IonType.Datagram;
+        public override IonType Type() => IonType.Datagram;
 
-        public override IonContainer Container
+        public override IIonContainer Container
         {
             get => null;
-            internal set => throw new InvalidOperationException("Cannot set the container of an Ion Datagram");
+            set => throw new InvalidOperationException("Cannot set the container of an Ion Datagram");
         }
 
         /// <summary>
         /// Adding an item to the datagram will mark the current symbol table.
         /// </summary>
-        public override void Add(IonValue item)
+        public override void Add(IIonValue item)
         {
             base.Add(item);
             Debug.Assert(item != null, nameof(item) + " != null");
         }
+
+        public IIonValue[] ToArray()
+        {
+            IIonValue[] nn = new IIonValue[this.Count];
+            int i = 0;
+            foreach (var ionValue in this)
+            {
+                nn[i++] = ionValue;
+            }
+            return nn;
+        }
+
+        public int GetHashCode(IonValue obj) => obj.GetHashCode();
     }
 }

--- a/IonDotnet/Tree/Impl/IonDatagram.cs
+++ b/IonDotnet/Tree/Impl/IonDatagram.cs
@@ -36,17 +36,6 @@ namespace IonDotnet.Tree.Impl
             Debug.Assert(item != null, nameof(item) + " != null");
         }
 
-        public IIonValue[] ToArray()
-        {
-            IIonValue[] nn = new IIonValue[this.Count];
-            int i = 0;
-            foreach (var ionValue in this)
-            {
-                nn[i++] = ionValue;
-            }
-            return nn;
-        }
-
         public int GetHashCode(IonValue obj) => obj.GetHashCode();
     }
 }

--- a/IonDotnet/Tree/Impl/IonDecimal.cs
+++ b/IonDotnet/Tree/Impl/IonDecimal.cs
@@ -26,7 +26,7 @@ namespace IonDotnet.Tree.Impl
 
         public static IonDecimal NewNull() => new IonDecimal(true);
 
-        public override bool IsEquivalentTo(IonValue other)
+        public override bool IsEquivalentTo(IIonValue other)
         {
             if (!base.IsEquivalentTo(other))
                 return false;
@@ -91,6 +91,6 @@ namespace IonDotnet.Tree.Impl
             }
         }
 
-        public override IonType Type => IonType.Decimal;
+        public override IonType Type() => IonType.Decimal;
     }
 }

--- a/IonDotnet/Tree/Impl/IonDecimal.cs
+++ b/IonDotnet/Tree/Impl/IonDecimal.cs
@@ -63,7 +63,7 @@ namespace IonDotnet.Tree.Impl
             writer.WriteDecimal(BigDecimalValue);
         }
 
-        public decimal DecimalValue
+        public override decimal DecimalValue
         {
             get
             {
@@ -77,7 +77,7 @@ namespace IonDotnet.Tree.Impl
             }
         }
 
-        public BigDecimal BigDecimalValue
+        public override BigDecimal BigDecimalValue
         {
             get
             {

--- a/IonDotnet/Tree/Impl/IonFloat.cs
+++ b/IonDotnet/Tree/Impl/IonFloat.cs
@@ -42,7 +42,7 @@ namespace IonDotnet.Tree.Impl
             if (PrivateHelper.IsNegativeZero(_d) ^ PrivateHelper.IsNegativeZero(oFloat._d))
                 return false;
 
-            return EqualityComparer<double>.Default.Equals(oFloat.Value, Value);
+            return EqualityComparer<double>.Default.Equals(oFloat.FloatValue, FloatValue);
         }
 
         internal override void WriteBodyTo(IPrivateWriter writer)
@@ -59,7 +59,7 @@ namespace IonDotnet.Tree.Impl
         /// <summary>
         /// Get or set the value of this float as <see cref="System.Double"/>.
         /// </summary>
-        public double Value
+        public override double FloatValue
         {
             get
             {

--- a/IonDotnet/Tree/Impl/IonFloat.cs
+++ b/IonDotnet/Tree/Impl/IonFloat.cs
@@ -27,7 +27,7 @@ namespace IonDotnet.Tree.Impl
         /// </summary>
         public static IonFloat NewNull() => new IonFloat(true);
 
-        public override bool IsEquivalentTo(IonValue other)
+        public override bool IsEquivalentTo(IIonValue other)
         {
             if (!base.IsEquivalentTo(other))
                 return false;
@@ -74,6 +74,6 @@ namespace IonDotnet.Tree.Impl
             }
         }
 
-        public override IonType Type => IonType.Float;
+        public override IonType Type() => IonType.Float;
     }
 }

--- a/IonDotnet/Tree/Impl/IonFloat.cs
+++ b/IonDotnet/Tree/Impl/IonFloat.cs
@@ -42,7 +42,7 @@ namespace IonDotnet.Tree.Impl
             if (PrivateHelper.IsNegativeZero(_d) ^ PrivateHelper.IsNegativeZero(oFloat._d))
                 return false;
 
-            return EqualityComparer<double>.Default.Equals(oFloat.FloatValue, FloatValue);
+            return EqualityComparer<double>.Default.Equals(oFloat.DoubleValue, DoubleValue);
         }
 
         internal override void WriteBodyTo(IPrivateWriter writer)
@@ -59,7 +59,7 @@ namespace IonDotnet.Tree.Impl
         /// <summary>
         /// Get or set the value of this float as <see cref="System.Double"/>.
         /// </summary>
-        public override double FloatValue
+        public override double DoubleValue
         {
             get
             {

--- a/IonDotnet/Tree/Impl/IonInt.cs
+++ b/IonDotnet/Tree/Impl/IonInt.cs
@@ -78,7 +78,7 @@ namespace IonDotnet.Tree.Impl
             writer.WriteInt(_longValue);
         }
 
-        public int IntValue
+        public override int IntValue
         {
             get
             {
@@ -90,7 +90,7 @@ namespace IonDotnet.Tree.Impl
             set => LongValue = value;
         }
 
-        public long LongValue
+        public override long LongValue
         {
             get
             {
@@ -110,7 +110,7 @@ namespace IonDotnet.Tree.Impl
             }
         }
 
-        public BigInteger BigIntegerValue
+        public override BigInteger BigIntegerValue
         {
             get
             {
@@ -133,7 +133,7 @@ namespace IonDotnet.Tree.Impl
             }
         }
 
-        public IntegerSize IntegerSize
+        public override IntegerSize IntegerSize
         {
             get
             {

--- a/IonDotnet/Tree/Impl/IonInt.cs
+++ b/IonDotnet/Tree/Impl/IonInt.cs
@@ -35,7 +35,7 @@ namespace IonDotnet.Tree.Impl
         /// </summary>
         public static IonInt NewNull() => new IonInt(true);
 
-        public override bool IsEquivalentTo(IonValue other)
+        public override bool IsEquivalentTo(IIonValue other)
         {
             if (!base.IsEquivalentTo(other))
                 return false;
@@ -145,7 +145,7 @@ namespace IonDotnet.Tree.Impl
             }
         }
 
-        public override IonType Type => IonType.Int;
+        public override IonType Type() => IonType.Int;
 
         private void SetSize(IntegerSize size)
         {

--- a/IonDotnet/Tree/Impl/IonList.cs
+++ b/IonDotnet/Tree/Impl/IonList.cs
@@ -19,6 +19,6 @@ namespace IonDotnet.Tree.Impl
         /// </summary>
         public static IonList NewNull() => new IonList(true);
 
-        public override IonType Type => IonType.List;
+        public override IonType Type() => IonType.List;
     }
 }

--- a/IonDotnet/Tree/Impl/IonLob.cs
+++ b/IonDotnet/Tree/Impl/IonLob.cs
@@ -25,7 +25,7 @@ namespace IonDotnet.Tree.Impl
         /// </summary>
         /// <returns>Read-only view of the bytes in this lob.</returns>
         /// <exception cref="NullValueException">If this lob is null.</exception>
-        public ReadOnlySpan<byte> Bytes()
+        public override ReadOnlySpan<byte> Bytes()
         {
             ThrowIfNull();
             Debug.Assert(ByteBuffer != null);
@@ -36,7 +36,7 @@ namespace IonDotnet.Tree.Impl
         /// Copy the bytes from the buffer to this lob.
         /// </summary>
         /// <param name="buffer">Byte buffer</param>
-        public void SetBytes(ReadOnlySpan<byte> buffer)
+        public override void SetBytes(ReadOnlySpan<byte> buffer)
         {
             ThrowIfLocked();
             //this is bad but this operation is pretty non-common.

--- a/IonDotnet/Tree/Impl/IonNull.cs
+++ b/IonDotnet/Tree/Impl/IonNull.cs
@@ -14,6 +14,6 @@ namespace IonDotnet.Tree.Impl
 
         internal override void WriteBodyTo(IPrivateWriter writer) => writer.WriteNull();
 
-        public override IonType Type => IonType.Null;
+        public override IonType Type() => IonType.Null;
     }
 }

--- a/IonDotnet/Tree/Impl/IonSequence.cs
+++ b/IonDotnet/Tree/Impl/IonSequence.cs
@@ -120,6 +120,16 @@ namespace IonDotnet.Tree.Impl
             Remove(_children[index]);
         }
 
+        public override IIonValue GetElementAt(int index)
+        {
+            ThrowIfNull();
+            if (index >= _children.Count)
+                throw new IndexOutOfRangeException($"Container has only {_children.Count} children");
+
+            //this will check for lock
+            return this[index];
+        }
+
         public override bool IsEquivalentTo(IIonValue other)
         {
             if (!base.IsEquivalentTo(other))

--- a/IonDotnet/Tree/Impl/IonSequence.cs
+++ b/IonDotnet/Tree/Impl/IonSequence.cs
@@ -110,7 +110,7 @@ namespace IonDotnet.Tree.Impl
             item.Container = this;
         }
 
-        public void RemoveAt(int index)
+        public override void RemoveAt(int index)
         {
             ThrowIfNull();
             if (index >= _children.Count)

--- a/IonDotnet/Tree/Impl/IonSequence.cs
+++ b/IonDotnet/Tree/Impl/IonSequence.cs
@@ -9,15 +9,15 @@ namespace IonDotnet.Tree.Impl
     /// <summary>
     /// A container that is a sequence of values.
     /// </summary>
-    internal abstract class IonSequence : IonContainer, IList<IonValue>, IIonSequence
+    internal abstract class IonSequence : IonContainer, IList<IIonValue>, IIonSequence
     {
-        private List<IonValue> _children;
+        private List<IIonValue> _children;
 
         protected IonSequence(bool isNull) : base(isNull)
         {
             if (!isNull)
             {
-                _children = new List<IonValue>();
+                _children = new List<IIonValue>();
             }
         }
 
@@ -25,13 +25,13 @@ namespace IonDotnet.Tree.Impl
         {
             if (NullFlagOn())
             {
-                writer.WriteNull(Type);
+                writer.WriteNull(Type());
                 return;
             }
 
             Debug.Assert(_children != null);
 
-            var type = Type;
+            var type = Type();
 
             if (type != IonType.Datagram)
             {
@@ -55,7 +55,7 @@ namespace IonDotnet.Tree.Impl
         /// </summary>
         public override int Count => _children?.Count ?? 0;
 
-        public int IndexOf(IonValue item)
+        public override int IndexOf(IIonValue item)
         {
             if (NullFlagOn())
                 return -1;
@@ -64,7 +64,7 @@ namespace IonDotnet.Tree.Impl
             return _children.IndexOf(item);
         }
 
-        public override void Add(IonValue item)
+        public override void Add(IIonValue item)
         {
             ThrowIfLocked();
             ThrowIfNull();
@@ -83,7 +83,7 @@ namespace IonDotnet.Tree.Impl
         /// </summary>
         /// <param name="item"></param>
         /// <returns>True if the item has been removed</returns>
-        public override bool Remove(IonValue item)
+        public override bool Remove(IIonValue item)
         {
             ThrowIfLocked();
             ThrowIfNull();
@@ -96,7 +96,7 @@ namespace IonDotnet.Tree.Impl
             return true;
         }
 
-        public virtual void Insert(int index, IonValue item)
+        public virtual void Insert(int index, IIonValue item)
         {
             ThrowIfLocked();
             ThrowIfNull();
@@ -120,7 +120,7 @@ namespace IonDotnet.Tree.Impl
             Remove(_children[index]);
         }
 
-        public override bool IsEquivalentTo(IonValue other)
+        public override bool IsEquivalentTo(IIonValue other)
         {
             if (!base.IsEquivalentTo(other))
                 return false;
@@ -153,7 +153,7 @@ namespace IonDotnet.Tree.Impl
             ThrowIfLocked();
             if (NullFlagOn() && _children == null)
             {
-                _children = new List<IonValue>();
+                _children = new List<IIonValue>();
             }
 
             foreach (var child in _children)
@@ -165,7 +165,7 @@ namespace IonDotnet.Tree.Impl
             _children.Clear();
         }
 
-        public override bool Contains(IonValue item)
+        public override bool Contains(IIonValue item)
         {
             if (NullFlagOn() || item == null)
                 return false;
@@ -173,7 +173,7 @@ namespace IonDotnet.Tree.Impl
             return item.Container == this;
         }
 
-        public IonValue this[int index]
+        public IIonValue this[int index]
         {
             get
             {
@@ -188,7 +188,7 @@ namespace IonDotnet.Tree.Impl
             }
         }
 
-        public override IEnumerator<IonValue> GetEnumerator()
+        public override IEnumerator<IIonValue> GetEnumerator()
         {
             ThrowIfNull();
             return _children.GetEnumerator();

--- a/IonDotnet/Tree/Impl/IonSexp.cs
+++ b/IonDotnet/Tree/Impl/IonSexp.cs
@@ -19,6 +19,6 @@ namespace IonDotnet.Tree.Impl
         /// </summary>
         public static IonSexp NewNull() => new IonSexp(true);
 
-        public override IonType Type => IonType.Sexp;
+        public override IonType Type() => IonType.Sexp;
     }
 }

--- a/IonDotnet/Tree/Impl/IonString.cs
+++ b/IonDotnet/Tree/Impl/IonString.cs
@@ -17,11 +17,11 @@ namespace IonDotnet.Tree.Impl
         /// </summary>
         public static IonString NewNull() => new IonString(null);
 
-        public override bool IsEquivalentTo(IonValue other)
+        public override bool IsEquivalentTo(IIonValue other)
         {
             if (!base.IsEquivalentTo(other))
                 return false;
-            
+
             if (!(other is IonString otherString))
                 return false;
             return StringVal == otherString.StringVal;
@@ -29,6 +29,6 @@ namespace IonDotnet.Tree.Impl
 
         internal override void WriteBodyTo(IPrivateWriter writer) => writer.WriteString(StringVal);
 
-        public override IonType Type => IonType.String;
+        public override IonType Type() => IonType.String;
     }
 }

--- a/IonDotnet/Tree/Impl/IonStruct.cs
+++ b/IonDotnet/Tree/Impl/IonStruct.cs
@@ -181,7 +181,7 @@ namespace IonDotnet.Tree.Impl
         /// <param name="fieldName">Field name.</param>
         /// <returns>True if the field was removed, false otherwise.</returns>
         /// <exception cref="ArgumentNullException">When <paramref name="fieldName"/> is empty.</exception>
-        public bool RemoveField(string fieldName)
+        public override bool RemoveField(string fieldName)
         {
             ThrowIfNull();
             ThrowIfLocked();
@@ -193,7 +193,7 @@ namespace IonDotnet.Tree.Impl
         }
 
         /// <returns>True if the struct contains such field name.</returns>
-        public bool ContainsField(string fieldName)
+        public override bool ContainsField(string fieldName)
             => _values != null && _values.Any(v => v.FieldNameSymbol.Text == fieldName);
 
         /// <summary>

--- a/IonDotnet/Tree/Impl/IonStruct.cs
+++ b/IonDotnet/Tree/Impl/IonStruct.cs
@@ -8,7 +8,7 @@ namespace IonDotnet.Tree.Impl
 {
     internal sealed class IonStruct : IonContainer, IIonStruct
     {
-        private List<IonValue> _values;
+        private List<IIonValue> _values;
 
         public IonStruct() : this(false)
         {
@@ -18,7 +18,7 @@ namespace IonDotnet.Tree.Impl
         {
             if (!isNull)
             {
-                _values = new List<IonValue>();
+                _values = new List<IIonValue>();
             }
         }
 
@@ -31,7 +31,7 @@ namespace IonDotnet.Tree.Impl
         /// <remarks>
         /// Struct equivalence is an expensive operation.
         /// </remarks>
-        public override bool IsEquivalentTo(IonValue other)
+        public override bool IsEquivalentTo(IIonValue other)
         {
             if (!base.IsEquivalentTo(other))
                 return false;
@@ -77,9 +77,9 @@ namespace IonDotnet.Tree.Impl
             writer.StepOut();
         }
 
-        public override IonType Type => IonType.Struct;
+        public override IonType Type() => IonType.Struct;
 
-        public override void Add(IonValue item)
+        public override void Add(IIonValue item)
             => throw new NotSupportedException("Cannot add a value to a struct without field name");
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace IonDotnet.Tree.Impl
         /// <param name="value">Ion value to add.</param>
         /// <exception cref="ArgumentNullException">When field name is null.</exception>
         /// <exception cref="ContainedValueException">If the value is already child of a container.</exception>
-        public void Add(string fieldName, IonValue value)
+        public void Add(string fieldName, IIonValue value)
         {
             if (fieldName is null)
                 throw new ArgumentNullException(nameof(fieldName));
@@ -103,7 +103,7 @@ namespace IonDotnet.Tree.Impl
             _values.Add(value);
         }
 
-        public void Add(SymbolToken symbol, IonValue value)
+        public void Add(SymbolToken symbol, IIonValue value)
         {
             if (symbol.Text != null)
             {
@@ -127,7 +127,7 @@ namespace IonDotnet.Tree.Impl
         {
             ThrowIfLocked();
             if (NullFlagOn() && _values == null)
-                _values = new List<IonValue>();
+                _values = new List<IIonValue>();
 
             NullFlagOn(false);
             foreach (var v in _values)
@@ -138,7 +138,7 @@ namespace IonDotnet.Tree.Impl
             _values.Clear();
         }
 
-        public override bool Contains(IonValue item)
+        public override bool Contains(IIonValue item)
         {
             if (NullFlagOn() || item is null)
                 return false;
@@ -147,7 +147,7 @@ namespace IonDotnet.Tree.Impl
             return item.Container == this;
         }
 
-        public override IEnumerator<IonValue> GetEnumerator()
+        public override IEnumerator<IIonValue> GetEnumerator()
         {
             if (NullFlagOn())
                 yield break;
@@ -158,7 +158,7 @@ namespace IonDotnet.Tree.Impl
             }
         }
 
-        public override bool Remove(IonValue item)
+        public override bool Remove(IIonValue item)
         {
             ThrowIfNull();
             ThrowIfLocked();
@@ -203,7 +203,7 @@ namespace IonDotnet.Tree.Impl
         /// <param name="fieldName">Field name.</param>
         /// <exception cref="ArgumentNullException">When field name is null.</exception>
         /// <exception cref="ContainedValueException">If the value being set is already contained in another container.</exception>
-        public IonValue this[string fieldName]
+        public IIonValue this[string fieldName]
         {
             get
             {
@@ -278,10 +278,10 @@ namespace IonDotnet.Tree.Impl
         private class MultisetField
         {
             private readonly SymbolToken _name;
-            private readonly IonValue _value;
+            private readonly IIonValue _value;
             public int Count;
 
-            public MultisetField(SymbolToken name, IonValue value)
+            public MultisetField(SymbolToken name, IIonValue value)
             {
                 Debug.Assert(name != null);
                 _name = name;

--- a/IonDotnet/Tree/Impl/IonSymbol.cs
+++ b/IonDotnet/Tree/Impl/IonSymbol.cs
@@ -63,7 +63,7 @@ namespace IonDotnet.Tree.Impl
             }
         }
 
-        public SymbolToken SymbolValue
+        public override SymbolToken SymbolValue
         {
             get => new SymbolToken(StringVal, _sid, _importLocation);
             set

--- a/IonDotnet/Tree/Impl/IonSymbol.cs
+++ b/IonDotnet/Tree/Impl/IonSymbol.cs
@@ -26,7 +26,7 @@ namespace IonDotnet.Tree.Impl
         /// </summary>
         public static IonSymbol NewNull() => new IonSymbol(true);
 
-        public override bool IsEquivalentTo(IonValue other)
+        public override bool IsEquivalentTo(IIonValue other)
         {
             if (!base.IsEquivalentTo(other))
                 return false;
@@ -51,7 +51,7 @@ namespace IonDotnet.Tree.Impl
             writer.WriteSymbolToken(SymbolValue);
         }
 
-        public override IonType Type => IonType.Symbol;
+        public override IonType Type() => IonType.Symbol;
 
         public override string StringValue
         {

--- a/IonDotnet/Tree/Impl/IonText.cs
+++ b/IonDotnet/Tree/Impl/IonText.cs
@@ -16,7 +16,7 @@ namespace IonDotnet.Tree.Impl
         /// <summary>
         /// Textual value as string.
         /// </summary>
-        public virtual string StringValue
+        public override string StringValue
         {
             get => StringVal;
             set

--- a/IonDotnet/Tree/Impl/IonTimestamp.cs
+++ b/IonDotnet/Tree/Impl/IonTimestamp.cs
@@ -44,7 +44,7 @@ namespace IonDotnet.Tree.Impl
             writer.WriteTimestamp(_timestamp);
         }
 
-        public Timestamp Value
+        public override Timestamp TimestampValue
         {
             get
             {

--- a/IonDotnet/Tree/Impl/IonTimestamp.cs
+++ b/IonDotnet/Tree/Impl/IonTimestamp.cs
@@ -20,7 +20,7 @@ namespace IonDotnet.Tree.Impl
         /// </summary>
         public static IonTimestamp NewNull() => new IonTimestamp(true);
 
-        public override bool IsEquivalentTo(IonValue other)
+        public override bool IsEquivalentTo(IIonValue other)
         {
             if (!base.IsEquivalentTo(other))
                 return false;
@@ -58,6 +58,6 @@ namespace IonDotnet.Tree.Impl
             }
         }
 
-        public override IonType Type => IonType.Timestamp;
+        public override IonType Type() => IonType.Timestamp;
     }
 }

--- a/IonDotnet/Tree/Impl/IonValue.cs
+++ b/IonDotnet/Tree/Impl/IonValue.cs
@@ -357,7 +357,8 @@ namespace IonDotnet.Tree.Impl
         public void MakeReadOnly() => LockedFlagOn(true);
 
         // Applicable to IonDecimal
-        public virtual decimal DecimalValue {
+        public virtual decimal DecimalValue
+        {
             get => throw new InvalidOperationException(GetErrorMessage());
             set => throw new InvalidOperationException(GetErrorMessage());
         }
@@ -379,6 +380,7 @@ namespace IonDotnet.Tree.Impl
 
         // Applicable to IonInt
         public virtual IntegerSize IntegerSize => throw new InvalidOperationException(GetErrorMessage());
+
         public virtual BigInteger BigIntegerValue
         {
             get => throw new InvalidOperationException(GetErrorMessage());

--- a/IonDotnet/Tree/Impl/IonValue.cs
+++ b/IonDotnet/Tree/Impl/IonValue.cs
@@ -185,7 +185,7 @@ namespace IonDotnet.Tree.Impl
         /// <summary>
         /// Store the field name text and sid.
         /// </summary>
-        public SymbolToken FieldNameSymbol { get; internal set; }
+        public SymbolToken FieldNameSymbol { get; set; }
 
         protected IonValue(bool isNull)
         {
@@ -198,7 +198,7 @@ namespace IonDotnet.Tree.Impl
         /// <summary>
         /// The container of this value, or null if this is not part of one.
         /// </summary>
-        public virtual IonContainer Container { get; internal set; }
+        public virtual IIonContainer Container { get; set; }
 
         /// <summary>
         /// Get this value's user type annotations.
@@ -286,9 +286,9 @@ namespace IonDotnet.Tree.Impl
         /// Equivalency is determined by whether the <see cref="IonValue"/> objects has the same annotations,
         /// hold equal values, or in the case of container, they contain equivalent sets of children.
         /// </remarks>
-        public virtual bool IsEquivalentTo(IonValue other)
+        private bool IsEquivalentTo(IonValue other)
         {
-            if (other == null || Type != other.Type)
+            if (other == null || Type() != other.Type())
                 return false;
 
             var otherAnnotations = other._annotations;
@@ -349,15 +349,12 @@ namespace IonDotnet.Tree.Impl
 
         private string GetErrorMessage()
         {
-            return $"This operation is not supported for IonType {Type}";
+            return $"This operation is not supported for IonType {Type()}";
         }
 
         public bool IsReadOnly => LockedFlagOn();
 
         public void MakeReadOnly() => LockedFlagOn(true);
-
-        /// <summary>The <see cref="IonType"/> of this value.</summary>
-        public abstract IonType Type { get; }
 
         // Applicable to IonDecimal
         public virtual decimal DecimalValue {
@@ -439,7 +436,7 @@ namespace IonDotnet.Tree.Impl
             }
         }
 
-        public bool IsEquivalentTo(IIonValue value)
+        public virtual bool IsEquivalentTo(IIonValue value)
         {
             var valueIonValue = (IonValue)value;
             return IsEquivalentTo(valueIonValue);
@@ -476,6 +473,41 @@ namespace IonDotnet.Tree.Impl
         }
 
         public virtual void Clear()
+        {
+            throw new InvalidOperationException(GetErrorMessage());
+        }
+
+        public virtual void Add(IIonValue item)
+        {
+            throw new InvalidOperationException(GetErrorMessage());
+        }
+
+        public virtual int IndexOf(IIonValue item)
+        {
+            throw new InvalidOperationException(GetErrorMessage());
+        }
+
+        public virtual bool Remove(IIonValue item)
+        {
+            throw new InvalidOperationException(GetErrorMessage());
+        }
+
+        public virtual bool Contains(IIonValue item)
+        {
+            throw new InvalidOperationException(GetErrorMessage());
+        }
+
+        public virtual void CopyTo(IIonValue[] array, int arrayIndex)
+        {
+            throw new InvalidOperationException(GetErrorMessage());
+        }
+
+        public virtual IEnumerator<IIonValue> GetEnumerator()
+        {
+            throw new InvalidOperationException(GetErrorMessage());
+        }
+
+        public virtual IonType Type()
         {
             throw new InvalidOperationException(GetErrorMessage());
         }

--- a/IonDotnet/Tree/Impl/IonValue.cs
+++ b/IonDotnet/Tree/Impl/IonValue.cs
@@ -464,6 +464,11 @@ namespace IonDotnet.Tree.Impl
             throw new InvalidOperationException(GetErrorMessage());
         }
 
+        public virtual IIonValue GetElementAt(int index)
+        {
+            throw new InvalidOperationException(GetErrorMessage());
+        }
+
         public virtual bool RemoveField(string fieldName)
         {
             throw new InvalidOperationException(GetErrorMessage());

--- a/IonDotnet/Tree/Impl/IonValue.cs
+++ b/IonDotnet/Tree/Impl/IonValue.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Text;
 using IonDotnet.Builders;
 using IonDotnet.Internals;
 using IonDotnet.Internals.Text;
@@ -345,12 +347,86 @@ namespace IonDotnet.Tree.Impl
 //            throw new NotImplementedException();
 //        }
 
+        private string GetErrorMessage()
+        {
+            return $"This operation is not supported for IonType {Type}";
+        }
+
         public bool IsReadOnly => LockedFlagOn();
 
         public void MakeReadOnly() => LockedFlagOn(true);
 
         /// <summary>The <see cref="IonType"/> of this value.</summary>
         public abstract IonType Type { get; }
+
+        // Applicable to IonDecimal
+        public virtual decimal DecimalValue {
+            get => throw new InvalidOperationException(GetErrorMessage());
+            set => throw new InvalidOperationException(GetErrorMessage());
+        }
+        public virtual BigDecimal BigDecimalValue
+        {
+            get => throw new InvalidOperationException(GetErrorMessage());
+            set => throw new InvalidOperationException(GetErrorMessage());
+        }
+
+        // Applicable to IonContainer
+        public virtual int Count => throw new InvalidOperationException(GetErrorMessage());
+
+        // Applicable to IonText
+        public virtual string StringValue
+        {
+            get => throw new InvalidOperationException(GetErrorMessage());
+            set => throw new InvalidOperationException(GetErrorMessage());
+        }
+
+        // Applicable to IonInt
+        public virtual IntegerSize IntegerSize => throw new InvalidOperationException(GetErrorMessage());
+        public virtual BigInteger BigIntegerValue
+        {
+            get => throw new InvalidOperationException(GetErrorMessage());
+            set => throw new InvalidOperationException(GetErrorMessage());
+        }
+
+        public virtual int IntValue
+        {
+            get => throw new InvalidOperationException(GetErrorMessage());
+            set => throw new InvalidOperationException(GetErrorMessage());
+        }
+
+        public virtual long LongValue
+        {
+            get => throw new InvalidOperationException(GetErrorMessage());
+            set => throw new InvalidOperationException(GetErrorMessage());
+        }
+
+        // Applicable to IonSymbol
+        public virtual SymbolToken SymbolValue
+        {
+            get => throw new InvalidOperationException(GetErrorMessage());
+            set => throw new InvalidOperationException(GetErrorMessage());
+        }
+
+        // Applicable to IonBool
+        public virtual bool BoolValue
+        {
+            get => throw new InvalidOperationException(GetErrorMessage());
+            set => throw new InvalidOperationException(GetErrorMessage());
+        }
+
+        // Applicable to IonFloat
+        public virtual double FloatValue
+        {
+            get => throw new InvalidOperationException(GetErrorMessage());
+            set => throw new InvalidOperationException(GetErrorMessage());
+        }
+
+        // Applicable to IonTimestamp
+        public virtual Timestamp TimestampValue
+        {
+            get => throw new InvalidOperationException(GetErrorMessage());
+            set => throw new InvalidOperationException(GetErrorMessage());
+        }
 
         public string ToPrettyString()
         {
@@ -367,6 +443,41 @@ namespace IonDotnet.Tree.Impl
         {
             var valueIonValue = (IonValue)value;
             return IsEquivalentTo(valueIonValue);
+        }
+
+        public virtual ReadOnlySpan<byte> Bytes()
+        {
+            throw new InvalidOperationException(GetErrorMessage());
+        }
+
+        public virtual void SetBytes(ReadOnlySpan<byte> buffer)
+        {
+            throw new InvalidOperationException(GetErrorMessage());
+        }
+
+        public virtual StreamReader NewReader(Encoding encoding)
+        {
+            throw new InvalidOperationException(GetErrorMessage());
+        }
+
+        public virtual void RemoveAt(int index)
+        {
+            throw new InvalidOperationException(GetErrorMessage());
+        }
+
+        public virtual bool RemoveField(string fieldName)
+        {
+            throw new InvalidOperationException(GetErrorMessage());
+        }
+
+        public virtual bool ContainsField(string fieldName)
+        {
+            throw new InvalidOperationException(GetErrorMessage());
+        }
+
+        public virtual void Clear()
+        {
+            throw new InvalidOperationException(GetErrorMessage());
         }
     }
 }

--- a/IonDotnet/Tree/Impl/IonValue.cs
+++ b/IonDotnet/Tree/Impl/IonValue.cs
@@ -414,7 +414,7 @@ namespace IonDotnet.Tree.Impl
         }
 
         // Applicable to IonFloat
-        public virtual double FloatValue
+        public virtual double DoubleValue
         {
             get => throw new InvalidOperationException(GetErrorMessage());
             set => throw new InvalidOperationException(GetErrorMessage());


### PR DESCRIPTION
*Description of changes:*
Updated IsScalar() function to include blob and clob because they are also scalar values.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
