### PR TITLE
Add isFloatBinary64Enabled bool to BinaryWriterBuilder

### DIFF
--- a/IonDotnet.Tests/Internals/BinaryWriterTest.cs
+++ b/IonDotnet.Tests/Internals/BinaryWriterTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using IonDotnet.Internals.Binary;
 using IonDotnet.Tests.Common;
 using IonDotnet.Utils;
@@ -348,6 +349,32 @@ namespace IonDotnet.Tests.Internals
             }
 
             reader.StepOut();
+        }
+
+        [TestMethod]
+        [DataRow(2e0)]
+        public void WriteFloatWithForceFloatEnabledAndDisabled(double val)
+        {
+            int array32BitLength = 0;
+            int array64BitLength = 0;
+            using (var writer = new ManagedBinaryWriter(_memoryStream, Symbols.EmptySymbolTablesArray, forceFloat64: false))
+            {
+                writer.WriteFloat(val);
+                writer.Flush();
+                array32BitLength = _memoryStream.GetWrittenBuffer().Length;
+
+                _memoryStream.SetLength(0);
+            }
+
+            using (var writer = new ManagedBinaryWriter(_memoryStream, Symbols.EmptySymbolTablesArray, forceFloat64 : true))
+            {
+                writer.WriteFloat(val);
+                writer.Flush();
+                array64BitLength = _memoryStream.GetWrittenBuffer().Length;
+
+            }
+
+            Assert.AreEqual(array32BitLength + 4, array64BitLength);
         }
 
         /// <summary>

--- a/IonDotnet/Builders/IonBinaryWriterBuilder.cs
+++ b/IonDotnet/Builders/IonBinaryWriterBuilder.cs
@@ -12,11 +12,18 @@ namespace IonDotnet.Builders
         /// </summary>
         /// <param name="outputStream">Output stream.</param>
         /// <param name="imports">Imported symbol tables used to encode symbols.</param>
+        /// <param name="isFloat64BinaryEnabled">Write float value as 64 bit.</param>
         /// <returns>A new Ion writer.</returns>
-        public static IIonWriter Build(Stream outputStream, IEnumerable<ISymbolTable> imports = null)
+        public static IIonWriter Build(
+            Stream outputStream,
+            IEnumerable<ISymbolTable> imports = null,
+            bool isFloat64BinaryEnabled = false)
         {
             outputStream.CheckStreamCanWrite();
-            return new ManagedBinaryWriter(outputStream, imports ?? Symbols.EmptySymbolTablesArray);
+            return new ManagedBinaryWriter(
+                outputStream,
+                imports ?? Symbols.EmptySymbolTablesArray,
+                isFloat64BinaryEnabled);
         }
     }
 }

--- a/IonDotnet/Builders/IonBinaryWriterBuilder.cs
+++ b/IonDotnet/Builders/IonBinaryWriterBuilder.cs
@@ -12,18 +12,18 @@ namespace IonDotnet.Builders
         /// </summary>
         /// <param name="outputStream">Output stream.</param>
         /// <param name="imports">Imported symbol tables used to encode symbols.</param>
-        /// <param name="isFloat64BinaryEnabled">Write float value as 64 bit.</param>
+        /// <param name="isFloatBinary64Enabled">Write float value as 64 bit.</param>
         /// <returns>A new Ion writer.</returns>
         public static IIonWriter Build(
             Stream outputStream,
             IEnumerable<ISymbolTable> imports = null,
-            bool isFloat64BinaryEnabled = false)
+            bool isFloatBinary64Enabled = false)
         {
             outputStream.CheckStreamCanWrite();
             return new ManagedBinaryWriter(
                 outputStream,
                 imports ?? Symbols.EmptySymbolTablesArray,
-                isFloat64BinaryEnabled);
+                isFloatBinary64Enabled);
         }
     }
 }

--- a/IonDotnet/Builders/IonBinaryWriterBuilder.cs
+++ b/IonDotnet/Builders/IonBinaryWriterBuilder.cs
@@ -12,18 +12,19 @@ namespace IonDotnet.Builders
         /// </summary>
         /// <param name="outputStream">Output stream.</param>
         /// <param name="imports">Imported symbol tables used to encode symbols.</param>
-        /// <param name="isFloatBinary64Enabled">Write float value as 64 bit.</param>
+        /// <param name="forceFloat64">Always write float values in 64 bits. When false, float values will be
+        /// written in 32 bits when it is possible to do so without losing fidelity.</param>
         /// <returns>A new Ion writer.</returns>
         public static IIonWriter Build(
             Stream outputStream,
             IEnumerable<ISymbolTable> imports = null,
-            bool isFloatBinary64Enabled = false)
+            bool forceFloat64 = false)
         {
             outputStream.CheckStreamCanWrite();
             return new ManagedBinaryWriter(
                 outputStream,
                 imports ?? Symbols.EmptySymbolTablesArray,
-                isFloatBinary64Enabled);
+                forceFloat64);
         }
     }
 }

--- a/IonDotnet/Internals/Binary/ManagedBinaryWriter.cs
+++ b/IonDotnet/Internals/Binary/ManagedBinaryWriter.cs
@@ -107,7 +107,7 @@ namespace IonDotnet.Internals.Binary
         public ManagedBinaryWriter(
             Stream outputStream,
             IEnumerable<ISymbolTable> importedTables,
-            bool isFloat64BinaryEnabled = false)
+            bool isFloatBinary64Enabled = false)
         {
             if (!outputStream.CanWrite)
                 throw new ArgumentException("Output stream must be writable", nameof(outputStream));
@@ -120,12 +120,12 @@ namespace IonDotnet.Internals.Binary
                 lengthWriterBuffer,
                 new PagedWriter256Buffer(),
                 lengthSegment,
-                isFloat64BinaryEnabled);
+                isFloatBinary64Enabled);
             _userWriter = new RawBinaryWriter(
                 lengthWriterBuffer,
                 new PagedWriter256Buffer(),
                 lengthSegment,
-                isFloat64BinaryEnabled);
+                isFloatBinary64Enabled);
 
             _importContext = new ImportedSymbolsContext(importedTables);
             _locals = new Dictionary<string, int>();

--- a/IonDotnet/Internals/Binary/ManagedBinaryWriter.cs
+++ b/IonDotnet/Internals/Binary/ManagedBinaryWriter.cs
@@ -107,7 +107,7 @@ namespace IonDotnet.Internals.Binary
         public ManagedBinaryWriter(
             Stream outputStream,
             IEnumerable<ISymbolTable> importedTables,
-            bool isFloatBinary64Enabled = false)
+            bool forceFloat64 = false)
         {
             if (!outputStream.CanWrite)
                 throw new ArgumentException("Output stream must be writable", nameof(outputStream));
@@ -120,12 +120,12 @@ namespace IonDotnet.Internals.Binary
                 lengthWriterBuffer,
                 new PagedWriter256Buffer(),
                 lengthSegment,
-                isFloatBinary64Enabled);
+                forceFloat64);
             _userWriter = new RawBinaryWriter(
                 lengthWriterBuffer,
                 new PagedWriter256Buffer(),
                 lengthSegment,
-                isFloatBinary64Enabled);
+                forceFloat64);
 
             _importContext = new ImportedSymbolsContext(importedTables);
             _locals = new Dictionary<string, int>();

--- a/IonDotnet/Internals/Binary/ManagedBinaryWriter.cs
+++ b/IonDotnet/Internals/Binary/ManagedBinaryWriter.cs
@@ -104,7 +104,10 @@ namespace IonDotnet.Internals.Binary
         private SymbolState _symbolState;
         private readonly Stream _outputStream;
 
-        public ManagedBinaryWriter(Stream outputStream, IEnumerable<ISymbolTable> importedTables)
+        public ManagedBinaryWriter(
+            Stream outputStream,
+            IEnumerable<ISymbolTable> importedTables,
+            bool isFloat64BinaryEnabled = false)
         {
             if (!outputStream.CanWrite)
                 throw new ArgumentException("Output stream must be writable", nameof(outputStream));
@@ -113,8 +116,16 @@ namespace IonDotnet.Internals.Binary
             //raw writers and their buffers
             var lengthWriterBuffer = new PagedWriter256Buffer();
             var lengthSegment = new List<Memory<byte>>(2);
-            _symbolsWriter = new RawBinaryWriter(lengthWriterBuffer, new PagedWriter256Buffer(), lengthSegment);
-            _userWriter = new RawBinaryWriter(lengthWriterBuffer, new PagedWriter256Buffer(), lengthSegment);
+            _symbolsWriter = new RawBinaryWriter(
+                lengthWriterBuffer,
+                new PagedWriter256Buffer(),
+                lengthSegment,
+                isFloat64BinaryEnabled);
+            _userWriter = new RawBinaryWriter(
+                lengthWriterBuffer,
+                new PagedWriter256Buffer(),
+                lengthSegment,
+                isFloat64BinaryEnabled);
 
             _importContext = new ImportedSymbolsContext(importedTables);
             _locals = new Dictionary<string, int>();

--- a/IonDotnet/Internals/Binary/RawBinaryWriter.cs
+++ b/IonDotnet/Internals/Binary/RawBinaryWriter.cs
@@ -511,7 +511,7 @@ namespace IonDotnet.Internals.Binary
             PrepareValue();
 
             // ReSharper disable once CompareOfFloatsByEqualityOperator
-            if (!_isFloat64BinaryEnabled && value == (float)value)
+            if (!_isFloat64BinaryEnabled && value == (float) value)
             {
                 //TODO requires careful testing
                 _containerStack.IncreaseCurrentContainerLength(5);

--- a/IonDotnet/Internals/Binary/RawBinaryWriter.cs
+++ b/IonDotnet/Internals/Binary/RawBinaryWriter.cs
@@ -59,17 +59,20 @@ namespace IonDotnet.Internals.Binary
         private SymbolToken _currentFieldSymbolToken;
         private readonly ContainerStack _containerStack;
         private readonly List<Memory<byte>> _lengthSegments;
+        private readonly bool _isFloat64BinaryEnabled;
 
-        internal RawBinaryWriter(IWriterBuffer lengthBuffer, IWriterBuffer dataBuffer, List<Memory<byte>> lengthSegments)
+        internal RawBinaryWriter(IWriterBuffer lengthBuffer, IWriterBuffer dataBuffer, List<Memory<byte>> lengthSegments, bool isFloat64BinaryEnabled)
         {
             _lengthBuffer = lengthBuffer;
             _dataBuffer = dataBuffer;
             _lengthSegments = lengthSegments;
             _containerStack = new ContainerStack(DefaultContainerStackSize);
+            _isFloat64BinaryEnabled = isFloat64BinaryEnabled;
 
             //top-level writing also requires a tracker
             var pushedContainer = _containerStack.PushContainer(ContainerType.Datagram);
             _dataBuffer.StartStreak(pushedContainer.Sequence);
+
         }
 
         /// <summary>
@@ -508,8 +511,8 @@ namespace IonDotnet.Internals.Binary
         {
             PrepareValue();
 
-            // ReSharper disable once CompareOfFloatsByEqualityOperator
-            if (value == (float) value)
+            //ReSharper disable once CompareOfFloatsByEqualityOperator
+            if (!_isFloat64BinaryEnabled && value == (float)value)
             {
                 //TODO requires careful testing
                 _containerStack.IncreaseCurrentContainerLength(5);

--- a/IonDotnet/Internals/Binary/RawBinaryWriter.cs
+++ b/IonDotnet/Internals/Binary/RawBinaryWriter.cs
@@ -59,15 +59,15 @@ namespace IonDotnet.Internals.Binary
         private SymbolToken _currentFieldSymbolToken;
         private readonly ContainerStack _containerStack;
         private readonly List<Memory<byte>> _lengthSegments;
-        private readonly bool _isFloat64BinaryEnabled;
+        private readonly bool _isFloatBinary64Enabled;
 
-        internal RawBinaryWriter(IWriterBuffer lengthBuffer, IWriterBuffer dataBuffer, List<Memory<byte>> lengthSegments, bool isFloat64BinaryEnabled)
+        internal RawBinaryWriter(IWriterBuffer lengthBuffer, IWriterBuffer dataBuffer, List<Memory<byte>> lengthSegments, bool isFloatBinary64Enabled)
         {
             _lengthBuffer = lengthBuffer;
             _dataBuffer = dataBuffer;
             _lengthSegments = lengthSegments;
             _containerStack = new ContainerStack(DefaultContainerStackSize);
-            _isFloat64BinaryEnabled = isFloat64BinaryEnabled;
+            _isFloatBinary64Enabled = isFloatBinary64Enabled;
 
             //top-level writing also requires a tracker
             var pushedContainer = _containerStack.PushContainer(ContainerType.Datagram);
@@ -511,7 +511,7 @@ namespace IonDotnet.Internals.Binary
             PrepareValue();
 
             // ReSharper disable once CompareOfFloatsByEqualityOperator
-            if (!_isFloat64BinaryEnabled && value == (float) value)
+            if (!_isFloatBinary64Enabled && value == (float) value)
             {
                 //TODO requires careful testing
                 _containerStack.IncreaseCurrentContainerLength(5);

--- a/IonDotnet/Internals/Binary/RawBinaryWriter.cs
+++ b/IonDotnet/Internals/Binary/RawBinaryWriter.cs
@@ -72,7 +72,6 @@ namespace IonDotnet.Internals.Binary
             //top-level writing also requires a tracker
             var pushedContainer = _containerStack.PushContainer(ContainerType.Datagram);
             _dataBuffer.StartStreak(pushedContainer.Sequence);
-
         }
 
         /// <summary>
@@ -511,7 +510,7 @@ namespace IonDotnet.Internals.Binary
         {
             PrepareValue();
 
-            //ReSharper disable once CompareOfFloatsByEqualityOperator
+            // ReSharper disable once CompareOfFloatsByEqualityOperator
             if (!_isFloat64BinaryEnabled && value == (float)value)
             {
                 //TODO requires careful testing

--- a/IonDotnet/Internals/Binary/RawBinaryWriter.cs
+++ b/IonDotnet/Internals/Binary/RawBinaryWriter.cs
@@ -59,15 +59,15 @@ namespace IonDotnet.Internals.Binary
         private SymbolToken _currentFieldSymbolToken;
         private readonly ContainerStack _containerStack;
         private readonly List<Memory<byte>> _lengthSegments;
-        private readonly bool _isFloatBinary64Enabled;
+        private readonly bool _forceFloat64;
 
-        internal RawBinaryWriter(IWriterBuffer lengthBuffer, IWriterBuffer dataBuffer, List<Memory<byte>> lengthSegments, bool isFloatBinary64Enabled)
+        internal RawBinaryWriter(IWriterBuffer lengthBuffer, IWriterBuffer dataBuffer, List<Memory<byte>> lengthSegments, bool forceFloat64)
         {
             _lengthBuffer = lengthBuffer;
             _dataBuffer = dataBuffer;
             _lengthSegments = lengthSegments;
             _containerStack = new ContainerStack(DefaultContainerStackSize);
-            _isFloatBinary64Enabled = isFloatBinary64Enabled;
+            _forceFloat64 = forceFloat64;
 
             //top-level writing also requires a tracker
             var pushedContainer = _containerStack.PushContainer(ContainerType.Datagram);
@@ -511,7 +511,7 @@ namespace IonDotnet.Internals.Binary
             PrepareValue();
 
             // ReSharper disable once CompareOfFloatsByEqualityOperator
-            if (!_isFloatBinary64Enabled && value == (float) value)
+            if (!_forceFloat64 && value == (float) value)
             {
                 //TODO requires careful testing
                 _containerStack.IncreaseCurrentContainerLength(5);


### PR DESCRIPTION
*Issue #, if available:*
AQ-240

*Description of changes:*
Currently the binary writer will write a float as 4 bytes however Ion Hash requires floats represented as 8 bytes. The isFloat64BinaryEnabled bool will the float to be written as 8 bytes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
