### PR TITLE
Timezone should include both hour and minute

### DIFF
--- a/IonDotnet.Tests/Internals/TextReaderTimestampTest.cs
+++ b/IonDotnet.Tests/Internals/TextReaderTimestampTest.cs
@@ -36,19 +36,19 @@ namespace IonDotnet.Tests.Internals
         /// </summary>
         /// <param name="dateString"></param>
         /// <param name="expectedLocalOffset"></param>
-        [DataRow("2010-10-10T03:20+02:12", +(2 * 60 + 12))]
-        [DataRow("2010-10-10T03:20-02:12", -(2 * 60 + 12))]
-        [DataRow("2010-10-10T03:20+00:12", +(0 * 60 + 12))]
-        [DataRow("2010-10-10T03:20+02:00", +(2 * 60 + 00))]
+        [DataRow("2010-10-10T03:20+02:12", +(2 * 60 + 12), "2010-10-10 3:20:00 AM +02:12")]
+        [DataRow("2010-10-10T03:20-02:12", -(2 * 60 + 12), "2010-10-10 3:20:00 AM -02:12")]
+        [DataRow("2010-10-10T03:20+00:12", +(0 * 60 + 12), "2010-10-10 3:20:00 AM +00:12")]
+        [DataRow("2010-10-10T03:20+02:00", +(2 * 60 + 00), "2010-10-10 3:20:00 AM +02:00")]
         [TestMethod]
-        public void TimeZone_Hour_Minute(string dateString, int expectedLocalOffset)
+        public void TimeZone_Hour_Minute(string dateString, int expectedLocalOffset, string expectedDateTimeOffset)
         {
             var date = Timestamp.Parse(dateString);
             var localOffset = date.LocalOffset;
-            var LocalDateTime = date.DateTimeValue.ToString();
+            var LocalDateTime = date.AsDateTimeOffset().ToString();
 
             Assert.AreEqual(expectedLocalOffset, localOffset); 
-            Assert.AreEqual("2010-10-10 3:20:00 AM", LocalDateTime);
+            Assert.AreEqual(expectedDateTimeOffset, LocalDateTime);
         }
     }
 }

--- a/IonDotnet.Tests/Internals/TextReaderTimestampTest.cs
+++ b/IonDotnet.Tests/Internals/TextReaderTimestampTest.cs
@@ -36,19 +36,25 @@ namespace IonDotnet.Tests.Internals
         /// </summary>
         /// <param name="dateString"></param>
         /// <param name="expectedLocalOffset"></param>
-        [DataRow("2010-10-10T03:20+02:12", +(2 * 60 + 12), "2010-10-10 3:20:00 AM +02:12")]
-        [DataRow("2010-10-10T03:20-02:12", -(2 * 60 + 12), "2010-10-10 3:20:00 AM -02:12")]
-        [DataRow("2010-10-10T03:20+00:12", +(0 * 60 + 12), "2010-10-10 3:20:00 AM +00:12")]
-        [DataRow("2010-10-10T03:20+02:00", +(2 * 60 + 00), "2010-10-10 3:20:00 AM +02:00")]
+        [DataRow("2010-10-10T03:20+02:12", +(2 * 60 + 12), "3:20:00 AM +02:12")]
+        [DataRow("2010-10-10T03:20-02:12", -(2 * 60 + 12), "3:20:00 AM -02:12")]
+        [DataRow("2010-10-10T03:20+00:12", +(0 * 60 + 12), "3:20:00 AM +00:12")]
+        [DataRow("2010-10-10T03:20+02:00", +(2 * 60 + 00), "3:20:00 AM +02:00")]
         [TestMethod]
         public void TimeZone_Hour_Minute(string dateString, int expectedLocalOffset, string expectedDateTimeOffset)
         {
             var date = Timestamp.Parse(dateString);
             var localOffset = date.LocalOffset;
-            var LocalDateTime = date.AsDateTimeOffset().ToString();
+            var LocalDateTime = ExtractTimeAndTimeZone(date.AsDateTimeOffset());
 
             Assert.AreEqual(expectedLocalOffset, localOffset); 
             Assert.AreEqual(expectedDateTimeOffset, LocalDateTime);
+        }
+
+        private string ExtractTimeAndTimeZone(System.DateTimeOffset localDateTime)
+        {
+            var value = localDateTime.ToString();
+            return value.Substring(value.Length - 17);
         }
     }
 }

--- a/IonDotnet.Tests/Internals/TextReaderTimestampTest.cs
+++ b/IonDotnet.Tests/Internals/TextReaderTimestampTest.cs
@@ -35,20 +35,21 @@ namespace IonDotnet.Tests.Internals
         /// Test local timezone offset
         /// </summary>
         /// <param name="dateString"></param>
-        /// <param name="expectedLocalOffset"></param>
+        /// <param name="expectedLocalOffset"> Time zone offset in minutes</param>
+        /// <param name="expectedTimeOffset"></param>
         [DataRow("2010-10-10T03:20+02:12", +(2 * 60 + 12), "3:20:00 AM +02:12")]
         [DataRow("2010-10-10T03:20-02:12", -(2 * 60 + 12), "3:20:00 AM -02:12")]
         [DataRow("2010-10-10T03:20+00:12", +(0 * 60 + 12), "3:20:00 AM +00:12")]
         [DataRow("2010-10-10T03:20+02:00", +(2 * 60 + 00), "3:20:00 AM +02:00")]
         [TestMethod]
-        public void TimeZone_Hour_Minute(string dateString, int expectedLocalOffset, string expectedDateTimeOffset)
+        public void TimeZone_Hour_Minute(string dateString, int expectedLocalOffset, string expectedTimeOffset)
         {
             var date = Timestamp.Parse(dateString);
             var localOffset = date.LocalOffset;
             var LocalDateTime = ExtractTimeAndTimeZone(date.AsDateTimeOffset());
 
             Assert.AreEqual(expectedLocalOffset, localOffset); 
-            Assert.AreEqual(expectedDateTimeOffset, LocalDateTime);
+            Assert.AreEqual(expectedTimeOffset, LocalDateTime);
         }
 
         private string ExtractTimeAndTimeZone(System.DateTimeOffset localDateTime)

--- a/IonDotnet.Tests/Internals/TextReaderTimestampTest.cs
+++ b/IonDotnet.Tests/Internals/TextReaderTimestampTest.cs
@@ -30,5 +30,25 @@ namespace IonDotnet.Tests.Internals
             Assert.IsTrue(date.LocalOffset >= -14 * 60 && date.LocalOffset <= 14 * 60);
             Assert.IsTrue(date.Equals(expectedDate));
         }
+
+        /// <summary>
+        /// Test local timezone offset
+        /// </summary>
+        /// <param name="dateString"></param>
+        /// <param name="expectedLocalOffset"></param>
+        [DataRow("2010-10-10T03:20+02:12", +(2 * 60 + 12))]
+        [DataRow("2010-10-10T03:20-02:12", -(2 * 60 + 12))]
+        [DataRow("2010-10-10T03:20+00:12", +(0 * 60 + 12))]
+        [DataRow("2010-10-10T03:20+02:00", +(2 * 60 + 00))]
+        [TestMethod]
+        public void TimeZone_Hour_Minute(string dateString, int expectedLocalOffset)
+        {
+            var date = Timestamp.Parse(dateString);
+            var localOffset = date.LocalOffset;
+            var LocalDateTime = date.DateTimeValue.ToString();
+
+            Assert.AreEqual(expectedLocalOffset, localOffset); 
+            Assert.AreEqual("2010-10-10 3:20:00 AM", LocalDateTime);
+        }
     }
 }

--- a/IonDotnet/Timestamp.cs
+++ b/IonDotnet/Timestamp.cs
@@ -113,10 +113,7 @@ namespace IonDotnet
             switch (DateTimeValue.Kind)
             {
                 case DateTimeKind.Local:
-                    var hourOffset = LocalOffset / 60;
-                    var minuteOffsetRemainder = LocalOffset % 60;
-                    return new DateTimeOffset(DateTime.SpecifyKind(DateTimeValue, DateTimeKind.Unspecified), TimeSpan.FromHours(hourOffset))
-                           - TimeSpan.FromMinutes(minuteOffsetRemainder);
+                    return new DateTimeOffset(DateTime.SpecifyKind(DateTimeValue, DateTimeKind.Unspecified), TimeSpan.FromMinutes(LocalOffset));
                 case DateTimeKind.Unspecified:
                     throw new InvalidOperationException("Offset is unknown");
                 case DateTimeKind.Utc:


### PR DESCRIPTION
Current implementation deducts minute offset of the timezone from the time.
For example if we have ```2019-01-01T05:10+02:12``` after the time is pared, we will have ```2019-01-01T05:22+02:00```
