### PR TITLE
Decimal fixes

### DIFF
--- a/IonDotnet.Tests/Internals/BigDecimalTest.cs
+++ b/IonDotnet.Tests/Internals/BigDecimalTest.cs
@@ -204,7 +204,7 @@ namespace IonDotnet.Tests.Internals
         [DataRow("123.456d10", "123456d7")]
         [DataRow("-0", "-0d0")]
         [DataRow("0.12345d2", "12.345")]
-        [DataRow("0.12345d5", "12345.0")]
+        [DataRow("0.12345d5", "12345d0")]
         [DataRow("0.12345d4", "1234.5")]
         [DataRow("12345d-5", "1.2345d-1")]
         public void ToString_Simple(string text, string expected)

--- a/IonDotnet/BigDecimal.cs
+++ b/IonDotnet/BigDecimal.cs
@@ -10,7 +10,7 @@ namespace IonDotnet
 {
     /// <inheritdoc cref="IComparable" />
     /// <summary>
-    /// Represent a decimal-type number. This type extends <see cref="T:System.Decimal" /> to allow for larger number range and 
+    /// Represent a decimal-type number. This type extends <see cref="T:System.Decimal" /> to allow for larger number range and
     /// decimal places up to <see cref="F:IonDotnet.BigDecimal.MaxPrecision" />.
     /// </summary>
     public readonly struct BigDecimal : IComparable<BigDecimal>, IEquatable<BigDecimal>
@@ -411,7 +411,7 @@ namespace IonDotnet
             var sb = new StringBuilder(IntVal.ToString(CultureInfo.InvariantCulture));
             if (Scale == 0)
             {
-                sb.Append(".0");
+                sb.Append("d0");
             }
             else if (Scale < 0)
             {

--- a/IonDotnet/BigDecimal.cs
+++ b/IonDotnet/BigDecimal.cs
@@ -405,7 +405,7 @@ namespace IonDotnet
             //TODO improve this
             if (IsNegativeZero)
             {
-                return "-0d0";
+                return "-0d" + Scale;
             }
 
             var sb = new StringBuilder(IntVal.ToString(CultureInfo.InvariantCulture));

--- a/IonDotnet/Internals/Binary/RawBinaryWriter.cs
+++ b/IonDotnet/Internals/Binary/RawBinaryWriter.cs
@@ -90,8 +90,8 @@ namespace IonDotnet.Internals.Binary
 
             if (_annotations.Count > 0)
             {
-                //Since annotations 'wraps' the actual value, we basically won't know the length 
-                //(the upcoming value might be another container) 
+                //Since annotations 'wraps' the actual value, we basically won't know the length
+                //(the upcoming value might be another container)
                 //so we treat this as another container of type 'annotation'
 
                 //add all written segments to the sequence
@@ -545,6 +545,13 @@ namespace IonDotnet.Internals.Binary
 
         public void WriteDecimal(BigDecimal value)
         {
+            decimal valueAsDecimal = value.ToDecimal();
+            if (valueAsDecimal == 0 && value.Scale == 0 && !value.IsNegativeZero)
+            {
+                this.WriteDecimal(valueAsDecimal);
+                return;
+            }
+
             PrepareValue();
 
             //wrapup first
@@ -579,6 +586,10 @@ namespace IonDotnet.Internals.Binary
                     totalLength++;
                     _dataBuffer.WriteUint8(0b1000_0000);
                 }
+            }
+            else if (mag.IsZero)
+            {
+                bytes = new byte[] {};
             }
 
             totalLength += bytes.Length;

--- a/IonDotnet/Internals/Binary/RawBinaryWriter.cs
+++ b/IonDotnet/Internals/Binary/RawBinaryWriter.cs
@@ -545,10 +545,9 @@ namespace IonDotnet.Internals.Binary
 
         public void WriteDecimal(BigDecimal value)
         {
-            decimal valueAsDecimal = value.ToDecimal();
-            if (valueAsDecimal == 0 && value.Scale == 0 && !value.IsNegativeZero)
+            if (value.IntVal == 0 && value.Scale == 0 && !value.IsNegativeZero)
             {
-                this.WriteDecimal(valueAsDecimal);
+                this.WriteDecimal(value.ToDecimal());
                 return;
             }
 

--- a/IonDotnet/Internals/Binary/RawBinaryWriter.cs
+++ b/IonDotnet/Internals/Binary/RawBinaryWriter.cs
@@ -563,7 +563,7 @@ namespace IonDotnet.Internals.Binary
 
             _dataBuffer.StartStreak(newContainer.Sequence);
             var totalLength = _dataBuffer.WriteVarInt(-value.Scale);
-            var negative = value.IntVal < 0;
+            var negative = value.IntVal < 0 || value.IsNegativeZero;
             var mag = BigInteger.Abs(value.IntVal);
 
 #if NET45 || NETSTANDARD1_3 || NETSTANDARD2_0
@@ -578,7 +578,7 @@ namespace IonDotnet.Internals.Binary
                 if ((bytes[0] & 0b1000_0000) == 0)
                 {
                     //bytes[0] can store the sign bit
-                    bytes[0] &= 0b1000_0000;
+                    bytes[0] |= 0b1000_0000;
                 }
                 else
                 {


### PR DESCRIPTION
- Fix BigDecimal ToString() for negative zero and scale 0
- Fix extra bytes being written for decimal 0 with scale 0
- Fix missing check for negative zero for negative flag
- Fix a & that should've been a |
- Fix the addition of un-needed bytes on a BigDecimal with magnitude 0