### PR TITLE
Allow more valid whitespace characters

### DIFF
--- a/Amazon.IonDotnet.Tests/Integration/Vector.cs
+++ b/Amazon.IonDotnet.Tests/Integration/Vector.cs
@@ -41,7 +41,6 @@ namespace Amazon.IonDotnet.Tests.Integration
         private static readonly HashSet<string> Excludes = new HashSet<string>
         {
             "subfieldVarInt.ion",
-            "whitespace.ion",
             "localSymbolTableAppend.ion",
             "stringUtf8.ion"
 

--- a/Amazon.IonDotnet/Internals/Text/TextConstants.cs
+++ b/Amazon.IonDotnet/Internals/Text/TextConstants.cs
@@ -356,6 +356,8 @@ namespace Amazon.IonDotnet.Internals.Text
                 case '\t':
                 case '\n':
                 case '\r':
+                case '\v':
+                case '\f':
                     // Whitespace
                     // case '/': // we check start of comment in the caller where we
                     //              can peek ahead for the following slash or asterisk

--- a/Amazon.IonDotnet/Internals/Text/TextScanner.cs
+++ b/Amazon.IonDotnet/Internals/Text/TextScanner.cs
@@ -926,6 +926,8 @@ namespace Amazon.IonDotnet.Internals.Text
                         goto Done;
                     case ' ':
                     case '\t':
+                    case '\v':
+                    case '\f':
                     case CharacterSequence.CharSeqNewlineSequence1:
                     case CharacterSequence.CharSeqNewlineSequence2:
                     case CharacterSequence.CharSeqNewlineSequence3:
@@ -1825,7 +1827,7 @@ namespace Amazon.IonDotnet.Internals.Text
         {
             // all forms of numeric need to stop someplace rational
             if (!IsTerminatingCharacter(c))
-                throw new FormatException($"Numeric value followed by invalid character: {numericText}{(char)c}");
+                throw new FormatException($"Numeric value [{numericText}] followed by invalid character: {(int)c}");
 
             // we read off the end of the number, so put back
             // what we don't want, but what ever we have is an int


### PR DESCRIPTION
*Issue:* #38

*Description of changes:* Allow vertical tab `\v` and form feed `\f` as whitespace characters.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
