### PR TITLE
Change Binary Constants to internal

### DIFF
--- a/Amazon.IonDotnet/Internals/Binary/BinaryConstants.cs
+++ b/Amazon.IonDotnet/Internals/Binary/BinaryConstants.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 
 namespace Amazon.IonDotnet.Internals.Binary
 {
-    public static class BinaryConstants
+    internal static class BinaryConstants
     {
         public const int BinaryVersionMarkerLength = 4;
 


### PR DESCRIPTION
Binary constants should only for where binary type code is needed and should only be accessible to its own assembly. I did global searches on BinaryConstants and IonType, they seem to be used as documented in the issue, where IonType is for public classes/methods and BinarConstants stay internal.

I also investigated the missing negative int in IonType, don't think that is a problem. Compared this to the ion-java, it doesn't have a negative int either. 

Please let me know if I misunderstood the issue. 

ion-dotnet issue #42 
