### PR TITLE
Remove JSON option in API

### DIFF
--- a/Amazon.IonDotnet/Builders/IonTextOptions.cs
+++ b/Amazon.IonDotnet/Builders/IonTextOptions.cs
@@ -37,11 +37,6 @@ namespace Amazon.IonDotnet.Builders
         public bool SymbolAsString { get; set; }
 
         /// <summary>
-        /// Write a JSON text
-        /// </summary>
-        public bool Json { get; set; }
-
-        /// <summary>
         /// Do we skip annotations?
         /// </summary>
         public bool SkipAnnotations { get; set; }

--- a/Amazon.IonDotnet/Internals/Text/IonTextWriter.cs
+++ b/Amazon.IonDotnet/Internals/Text/IonTextWriter.cs
@@ -113,15 +113,7 @@ namespace Amazon.IonDotnet.Internals.Text
         {
             if (_options.SymbolAsString)
             {
-                if (_options.Json)
-                {
-                    _textWriter.WriteJsonString(text);
-                }
-                else
-                {
-                    _textWriter.WriteString(text);
-                }
-
+                _textWriter.WriteString(text);
                 return;
             }
 
@@ -516,14 +508,7 @@ namespace Amazon.IonDotnet.Internals.Text
             }
 
             //double-quoted
-            if (_options.Json)
-            {
-                _textWriter.WriteJsonString(value);
-            }
-            else
-            {
-                _textWriter.WriteString(value);
-            }
+            _textWriter.WriteString(value);
 
             CloseValue();
         }


### PR DESCRIPTION
*Issue #, if available:*
[#79 Remove IonTextOptions.Json option from IonTextWriterBuilder API](https://github.com/amzn/ion-dotnet/issues/79)

*Description of changes:*
Since [Setting IonTextOptions.Json to true results in invalid JSON](https://github.com/amzn/ion-dotnet/issues/67) ticket milestone has been moved to Post-GA, we will need to remove the JSON option from the IonTextWriterBuilder so the user knows it is not supported at GA.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
