### PR TITLE
Fix for "stringUtf8.ion" test file

### DIFF
--- a/Amazon.IonDotnet.Tests/Integration/Vector.cs
+++ b/Amazon.IonDotnet.Tests/Integration/Vector.cs
@@ -41,8 +41,7 @@ namespace Amazon.IonDotnet.Tests.Integration
         private static readonly HashSet<string> Excludes = new HashSet<string>
         {
             "subfieldVarInt.ion",
-            "localSymbolTableAppend.ion",
-            "stringUtf8.ion"
+            "localSymbolTableAppend.ion"
 
         };
 

--- a/Amazon.IonDotnet/Internals/Text/TextScanner.cs
+++ b/Amazon.IonDotnet/Internals/Text/TextScanner.cs
@@ -1051,10 +1051,7 @@ namespace Amazon.IonDotnet.Internals.Text
                     {
                         sb.Append((char)c);
                         c = ReadChar();
-                        if ((char)c == '\\')
-                        {
-                            c = ReadEscapedChar(c, isClob);
-                        }
+                        c = ReadEscapedChar(c, isClob);
                         if (!char.IsLowSurrogate((char)c))
                         {
                             throw new IonException($"Invalid character format {(char)c}");

--- a/Amazon.IonDotnet/Internals/Text/TextScanner.cs
+++ b/Amazon.IonDotnet/Internals/Text/TextScanner.cs
@@ -1051,6 +1051,10 @@ namespace Amazon.IonDotnet.Internals.Text
                     {
                         sb.Append((char)c);
                         c = ReadChar();
+                        if ((char)c == '\\')
+                        {
+                            c = ReadEscapedChar(c, isClob);
+                        }
                         if (!char.IsLowSurrogate((char)c))
                         {
                             throw new IonException($"Invalid character format {(char)c}");


### PR DESCRIPTION
Fixed load process for surrogate pairs- when reading a surrogate pair (ex. \ud800\udc00), ReadEscapedChar() method should be called to correctly read in the second part of the pair. ReadChar() will only get the next char of the stream, which is '\' .

Issue amzn#39