### PR TITLE
Fix failing float tests

### DIFF
--- a/Amazon.IonDotnet/Internals/Binary/RawBinaryWriter.cs
+++ b/Amazon.IonDotnet/Internals/Binary/RawBinaryWriter.cs
@@ -542,7 +542,17 @@ namespace Amazon.IonDotnet.Internals.Binary
             {
                 _containerStack.IncreaseCurrentContainerLength(9);
                 _dataBuffer.WriteByte(TidFloatByte | 8);
-                _dataBuffer.WriteUint64(BitConverterEx.DoubleToInt64Bits(value));
+
+                if (double.IsNaN(value))
+                {
+                    // Double.NaN is different between C# and Java
+                    // For consistency, map NaN to the long value for NaN in Java
+                    _dataBuffer.WriteUint64(9221120237041090560);
+                }
+                else
+                {
+                    _dataBuffer.WriteUint64(BitConverter.DoubleToInt64Bits(value));
+                }
             }
 
             FinishValue();

--- a/Amazon.IonDotnet/Internals/Binary/RawBinaryWriter.cs
+++ b/Amazon.IonDotnet/Internals/Binary/RawBinaryWriter.cs
@@ -547,7 +547,7 @@ namespace Amazon.IonDotnet.Internals.Binary
                 {
                     // Double.NaN is different between C# and Java
                     // For consistency, map NaN to the long value for NaN in Java
-                    _dataBuffer.WriteUint64(9221120237041090560);
+                    _dataBuffer.WriteUint64(0x7ff8000000000000L);
                 }
                 else
                 {

--- a/Amazon.IonDotnet/Internals/Text/IonTextRawWriter.cs
+++ b/Amazon.IonDotnet/Internals/Text/IonTextRawWriter.cs
@@ -228,9 +228,19 @@ namespace Amazon.IonDotnet.Internals.Text
                 return;
             }
 
-            //TODO find a better way
-            var str = d.ToString(CultureInfo.InvariantCulture);
-            _writer.Write(str);
+            String str;
+
+            // Differentiate between negative zero and zero.
+            if (d == 0 && BitConverter.DoubleToInt64Bits(d) < 0)
+            {
+                str = "-0e0";
+                _writer.Write(str);
+            }
+            else
+            {
+                str = d.ToString("R");
+                _writer.Write(str);
+            }
 
             foreach (var c in str)
             {

--- a/Amazon.IonDotnet/Internals/Text/IonTextRawWriter.cs
+++ b/Amazon.IonDotnet/Internals/Text/IonTextRawWriter.cs
@@ -238,6 +238,8 @@ namespace Amazon.IonDotnet.Internals.Text
             }
             else
             {
+                // Using "R" round-trip format specifier.
+                // Ensures the converted string can be parse back into the same numeric value.
                 str = d.ToString("R");
                 _writer.Write(str);
             }


### PR DESCRIPTION
Float test is failing in IonHashTest.ion

Issue https://github.com/amzn/ion-hash-dotnet/issues/10

The issue was mainly caused by the conversion from double to string using Double.ToString(CultureInfo.InvariantCulture), in which some precisions were lost when dealing with many decimal digits. By using the Round-trip ("R") Format Specifier, precision is maintained. For the NaN edge case, Java and C# have differing semantics, in the test case, we are using Java's, so we map to Java's value manually. 

