### PR TITLE
Fix float tests in ion-hash

### DIFF
--- a/Amazon.IonDotnet.Tests/Integration/FieldNameTest.cs
+++ b/Amazon.IonDotnet.Tests/Integration/FieldNameTest.cs
@@ -13,7 +13,7 @@ namespace Amazon.IonDotnet.Tests.Integration
         [DataRow("fieldNameInf", "inf")]
         [DataRow("fieldNameQuotedFalse", "false")]
         [DataRow("fieldNameQuotedNan", "nan")]
-        [DataRow("fieldNameQuotedNegInf", "+inf")]
+        [DataRow("fieldNameQuotedNegInf", "-inf")]
         [DataRow("fieldNameQuotedNull", "null")]
         [DataRow("fieldNameQuotedNullInt", "null.int")]
         [DataRow("fieldNameQuotedPosInf", "+inf")]

--- a/Amazon.IonDotnet.Tests/Integration/NumberTest.cs
+++ b/Amazon.IonDotnet.Tests/Integration/NumberTest.cs
@@ -223,6 +223,18 @@ namespace Amazon.IonDotnet.Tests.Integration
         }
 
         [TestMethod]
+        public void FloatDblMax()
+        {
+            var file = DirStructure.IonTestFile("good/floatDblMax.ion");
+            var floats = new[]
+            {
+                1.7976931348623157e308
+            };
+
+            AssertReaderWriterPrescision(file, floats);
+        }
+
+        [TestMethod]
         public void FloatDblMin()
         {
             var file = DirStructure.IonTestFile("good/floatDblMin.ion");
@@ -234,37 +246,10 @@ namespace Amazon.IonDotnet.Tests.Integration
                 2.2250738585072012e-00308,
                 2.2250738585072012997800001e-308,
                 2.2250738585072014e-308,
-                2.2250738585072009e-308,
-                1.7976931348623157e308,
-                1.0000000000000002e0,
-                -1.0000000000000002e0
+                2.2250738585072009e-308
             };
 
-            void assertReader(IIonReader reader)
-            {
-                foreach (var f in floats)
-                {
-                    Assert.AreEqual(IonType.Float, reader.MoveNext());
-                    ReaderTestCommon.AssertFloatEqual(f, reader.DoubleValue());
-                }
-
-                Assert.AreEqual(IonType.None, reader.MoveNext());
-            }
-
-            void writerFunc(IIonWriter writer)
-            {
-                foreach (var f in floats)
-                {
-                    writer.WriteFloat(f);
-                }
-
-                writer.Finish();
-            }
-
-            var r = ReaderFromFile(file, InputStyle.FileStream);
-            assertReader(r);
-
-            AssertReaderWriter(assertReader, writerFunc);
+            AssertReaderWriterPrescision(file, floats);
         }
 
         [TestMethod]
@@ -337,6 +322,7 @@ namespace Amazon.IonDotnet.Tests.Integration
                         writer.Finish();
                     }
 
+                    // Confirm the reader's and writer's byte presentations are the same
                     var readerByte = BitConverter.GetBytes(reader.DoubleValue());
                     Array.Reverse(readerByte);
                     var writerByte = memoryStream.ToArray().Skip(5).ToArray();
@@ -345,6 +331,19 @@ namespace Amazon.IonDotnet.Tests.Integration
                 }
             }
 
+        }
+
+        [TestMethod]
+        public void FloatTrappedZeros()
+        {
+            var file = DirStructure.IonTestFile("good/float_trapped_zeros.ion");
+            var floats = new[]
+            {
+                1.0000000000000002e0,
+                -1.0000000000000002e0
+            };
+
+            AssertReaderWriterPrescision(file, floats);
         }
 
         [TestMethod]
@@ -420,6 +419,35 @@ namespace Amazon.IonDotnet.Tests.Integration
             }
 
             return co;
+        }
+
+        private void AssertReaderWriterPrescision(FileInfo file, double[] floats)
+        {
+            void assertReader(IIonReader reader)
+            {
+                foreach (var f in floats)
+                {
+                    Assert.AreEqual(IonType.Float, reader.MoveNext());
+                    ReaderTestCommon.AssertFloatEqual(f, reader.DoubleValue());
+                }
+
+                Assert.AreEqual(IonType.None, reader.MoveNext());
+            }
+
+            void writerFunc(IIonWriter writer)
+            {
+                foreach (var f in floats)
+                {
+                    writer.WriteFloat(f);
+                }
+
+                writer.Finish();
+            }
+
+            var r = ReaderFromFile(file, InputStyle.FileStream);
+            assertReader(r);
+
+            AssertReaderWriter(assertReader, writerFunc);
         }
     }
 }

--- a/Amazon.IonDotnet.Tests/Integration/NumberTest.cs
+++ b/Amazon.IonDotnet.Tests/Integration/NumberTest.cs
@@ -325,6 +325,7 @@ namespace Amazon.IonDotnet.Tests.Integration
                     // Confirm the reader's and writer's byte presentations are the same
                     var readerByte = BitConverter.GetBytes(reader.DoubleValue());
                     Array.Reverse(readerByte);
+                    // Get byte reprsentation of value from the stream
                     var writerByte = memoryStream.ToArray().Skip(5).ToArray();
 
                     Assert.IsTrue(Enumerable.SequenceEqual(writerByte, readerByte));

--- a/Amazon.IonDotnet.Tests/Integration/Vector.cs
+++ b/Amazon.IonDotnet.Tests/Integration/Vector.cs
@@ -41,8 +41,8 @@ namespace Amazon.IonDotnet.Tests.Integration
         private static readonly HashSet<string> Excludes = new HashSet<string>
         {
             "subfieldVarInt.ion",
-            "localSymbolTableAppend.ion"
-
+            "localSymbolTableAppend.ion",
+            "clobNewlines.ion"
         };
 
         private static readonly DirectoryInfo IonTestDir = DirStructure.IonTestDir();

--- a/Amazon.IonDotnet/Internals/Binary/RawBinaryWriter.cs
+++ b/Amazon.IonDotnet/Internals/Binary/RawBinaryWriter.cs
@@ -542,7 +542,17 @@ namespace Amazon.IonDotnet.Internals.Binary
             {
                 _containerStack.IncreaseCurrentContainerLength(9);
                 _dataBuffer.WriteByte(TidFloatByte | 8);
-                _dataBuffer.WriteUint64(BitConverterEx.DoubleToInt64Bits(value));
+
+                if (double.IsNaN(value))
+                {
+                    // Double.NaN is different between C# and Java
+                    // For consistency, map NaN to the long value for NaN in Java
+                    _dataBuffer.WriteUint64(9221120237041090560);
+                }
+                else
+                {
+                    _dataBuffer.WriteUint64(BitConverter.DoubleToInt64Bits(value));
+                }
             }
 
             FinishValue();

--- a/Amazon.IonDotnet/Internals/Binary/RawBinaryWriter.cs
+++ b/Amazon.IonDotnet/Internals/Binary/RawBinaryWriter.cs
@@ -547,7 +547,7 @@ namespace Amazon.IonDotnet.Internals.Binary
                 {
                     // Double.NaN is different between C# and Java
                     // For consistency, map NaN to the long value for NaN in Java
-                    _dataBuffer.WriteUint64(9221120237041090560);
+                    _dataBuffer.WriteUint64(0x7ff8000000000000L);
                 }
                 else
                 {

--- a/Amazon.IonDotnet/Internals/Text/IonTextRawWriter.cs
+++ b/Amazon.IonDotnet/Internals/Text/IonTextRawWriter.cs
@@ -228,9 +228,19 @@ namespace Amazon.IonDotnet.Internals.Text
                 return;
             }
 
-            //TODO find a better way
-            var str = d.ToString(CultureInfo.InvariantCulture);
-            _writer.Write(str);
+            String str;
+
+            // Differentiate between negative zero and zero.
+            if (d == 0 && BitConverter.DoubleToInt64Bits(d) < 0)
+            {
+                str = "-0e0";
+                _writer.Write(str);
+            }
+            else
+            {
+                str = d.ToString("R");
+                _writer.Write(str);
+            }
 
             foreach (var c in str)
             {

--- a/Amazon.IonDotnet/Internals/Text/IonTextRawWriter.cs
+++ b/Amazon.IonDotnet/Internals/Text/IonTextRawWriter.cs
@@ -238,6 +238,8 @@ namespace Amazon.IonDotnet.Internals.Text
             }
             else
             {
+                // Using "R" round-trip format specifier.
+                // Ensures the converted string can be parse back into the same numeric value.
                 str = d.ToString("R");
                 _writer.Write(str);
             }


### PR DESCRIPTION
Float test is failing in IonHashTest.ion

issue amzn/ion-hash-dotnet#10

The issue was mainly caused by the conversion from double to string using Double.ToString(CultureInfo.InvariantCulture), in which some precisions were lost when dealing with many decimal digits. By using the Round-trip ("R") Format Specifier, precision is maintained. For the NaN edge case, Java and C# have differing semantics, in the test case, we are using Java's, so we map to Java's value manually.

Ion-tests also had to change to accommodate the new test cases.
https://github.com/amzn/ion-tests/pull/67