### PR TITLE
Remove unnecessary symbol quote

### DIFF
--- a/Amazon.IonDotnet.Tests/Internals/TextWriterTest.cs
+++ b/Amazon.IonDotnet.Tests/Internals/TextWriterTest.cs
@@ -1,0 +1,69 @@
+﻿/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using System.IO;
+using System.Text;
+using Amazon.IonDotnet.Builders;
+using Amazon.IonDotnet.Internals.Text;
+using Amazon.IonDotnet.Tests.Common;
+using Amazon.IonDotnet.Tree.Impl;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Amazon.IonDotnet.Tests.Internals
+{
+    [TestClass]
+    public class TextWriterTest
+    {
+        [TestMethod]
+        public void NoSingleQuotesSymbol()
+        {
+            StringWriter sw = new StringWriter();
+            var textWriter = IonTextWriterBuilder.Build(sw);
+
+            textWriter.SetFieldName("hello");
+            textWriter.AddTypeAnnotation("ion");
+            textWriter.AddTypeAnnotation("hash");
+            textWriter.WriteSymbol("world");
+
+            Assert.AreEqual("null [5] null {hello:ion::hash::world}", sw.ToString());
+        }
+
+        [TestMethod]
+        public void NoQuoteSymbol2()
+        {
+            var text =
+                SystemSymbols.IonSymbolTable + "::" +
+                "{" +
+                "   symbols:[\"s1\", \"s2\"]" +
+                "}\n" +
+                "$10\n" +
+                "$11\n";
+            var ionValueFactory = new ValueFactory();
+            var datagram = IonLoader.Default.Load(text);
+            datagram.Add(ionValueFactory.NewSymbol("abc"));
+            datagram.Add(ionValueFactory.NewSymbol(new SymbolToken(null, 13))); // s3.
+            // Text.
+            var textOutput = new StringWriter();
+            var textWriter = IonTextWriterBuilder.Build(textOutput);
+            datagram.WriteTo(textWriter);
+            textWriter.Finish();
+            var expected = "s1 s2 abc $13";
+            var actual = textOutput.ToString();
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/Amazon.IonDotnet.Tests/Internals/TextWriterTest.cs
+++ b/Amazon.IonDotnet.Tests/Internals/TextWriterTest.cs
@@ -27,7 +27,7 @@ namespace Amazon.IonDotnet.Tests.Internals
         [TestMethod]
         public void NoQuotedSymbolAndFieldName()
         {
-            StringWriter sw = new StringWriter();
+            var sw = new StringWriter();
             var textWriter = IonTextWriterBuilder.Build(sw);
 
             textWriter.StepIn(IonType.Struct);
@@ -42,7 +42,7 @@ namespace Amazon.IonDotnet.Tests.Internals
         [TestMethod]
         public void QuotedSymbolAndFieldName()
         {
-            StringWriter sw = new StringWriter();
+            var sw = new StringWriter();
             var textWriter = IonTextWriterBuilder.Build(sw);
 
             textWriter.StepIn(IonType.Struct);
@@ -56,31 +56,29 @@ namespace Amazon.IonDotnet.Tests.Internals
 
 
         [TestMethod]
-        [DataRow("+inf", "nan", "s1 '+inf' 'nan' $13")]
-        [DataRow("s2", "abc", "s1 s2 abc $13")]
+        [DataRow("+inf", "nan", "s1 '+inf' 'nan'")]
+        [DataRow("s2", "abc", "s1 s2 abc")]
         public void WriteSymbolWithSymbolTable(String tableSym, String newSym, String expectedText)
         {
             var symbol = "symbols:[\"s1\", \"" + tableSym + "\"]";
-
-                var text =
+            var text =
                 SystemSymbols.IonSymbolTable + "::" +
                 "{" +
                 symbol +
                 "}\n" +
                 "$10\n" +
                 "$11\n";
+
             var ionValueFactory = new ValueFactory();
             var datagram = IonLoader.Default.Load(text);
             datagram.Add(ionValueFactory.NewSymbol(newSym));
-            datagram.Add(ionValueFactory.NewSymbol(new SymbolToken(null, 13))); 
 
-            // Text.
-            var textOutput = new StringWriter();
-            var textWriter = IonTextWriterBuilder.Build(textOutput);
+            var sw = new StringWriter();
+            var textWriter = IonTextWriterBuilder.Build(sw);
             datagram.WriteTo(textWriter);
             textWriter.Finish();
             var expected = expectedText;
-            var actual = textOutput.ToString();
+            var actual = sw.ToString();
             Assert.AreEqual(expected, actual);
         }
     }

--- a/Amazon.IonDotnet/Internals/Text/IonTextWriter.cs
+++ b/Amazon.IonDotnet/Internals/Text/IonTextWriter.cs
@@ -109,7 +109,7 @@ namespace Amazon.IonDotnet.Internals.Text
             }
         }
 
-        private void WriteSymbolText(string text, SymbolVariant symbolVariant = SymbolVariant.Unknown)
+        private void WriteSymbolText(string text)
         {
             if (_options.SymbolAsString)
             {
@@ -117,11 +117,8 @@ namespace Amazon.IonDotnet.Internals.Text
                 return;
             }
 
-            //TODO handle different kinds of SymbolVariant
-            if (symbolVariant == SymbolVariant.Unknown)
-            {
-                symbolVariant = GetSymbolVariant(text);
-            }
+            // Determine the variant for writing.
+            SymbolVariant symbolVariant = GetSymbolVariant(text);
 
             switch (symbolVariant)
             {
@@ -238,8 +235,7 @@ namespace Amazon.IonDotnet.Internals.Text
             }
             else
             {
-                //we write all symbol values with single-quote
-                WriteSymbolText(symbolToken.Text, SymbolVariant.Quoted);
+                WriteSymbolText(symbolToken.Text);
             }
 
             CloseValue();
@@ -250,7 +246,7 @@ namespace Amazon.IonDotnet.Internals.Text
             _isWritingIvm = true;
 
             StartValue();
-            WriteSymbolText(systemSymtab.IonVersionId, SymbolVariant.Identifier);
+            WriteSymbolText(systemSymtab.IonVersionId);
             CloseValue();
 
             _isWritingIvm = false;


### PR DESCRIPTION
Related to issue amzn#87

Removing an unnecessary parameter SymbolVariant in the WriteSymbolText method. Should always be using GetSymbolVariant to determine if the symbol or field name needs to be written with single quotes. The changes are matched to ion-Java, and the vector tests will also go through the WriteSymbolText method - all the existing tests pass.

Unit tests added with sample cases of quotation and no quotations.