### PR TITLE
Call FinishValue after wrinting a boolean value

### DIFF
--- a/Amazon.IonDotnet.Tests/Internals/BinaryWriterTest.cs
+++ b/Amazon.IonDotnet.Tests/Internals/BinaryWriterTest.cs
@@ -20,6 +20,8 @@ using System.Linq;
 using Amazon.IonDotnet.Builders;
 using Amazon.IonDotnet.Internals.Binary;
 using Amazon.IonDotnet.Tests.Common;
+using Amazon.IonDotnet.Tree;
+using Amazon.IonDotnet.Tree.Impl;
 using Amazon.IonDotnet.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -449,6 +451,37 @@ namespace Amazon.IonDotnet.Tests.Internals
             writeAndAdd("double", 231345.325667d * 133.346432d, writer.WriteFloat);
 
             return kvps;
+        }
+
+        [TestMethod]
+        public void WriteValuesWithAnnotation()
+        {
+            var ionValues = new List<IIonValue>();
+            var valueFactory = new ValueFactory();
+            ionValues.Add(valueFactory.NewBool(true));
+            ionValues.Add(valueFactory.NewString("string"));
+            ionValues.Add(valueFactory.NewFloat(22.22f));
+            ionValues.Add(valueFactory.NewDecimal(3.4m));
+            ionValues.Add(valueFactory.NewInt(3));
+            ionValues.Add(valueFactory.NewNull());
+            ionValues.Add(valueFactory.NewSymbol("symbol"));
+            ionValues.Add(valueFactory.NewTimestamp(new Timestamp(DateTime.Now)));
+            var arrayOfbytes = Enumerable.Repeat<byte>(1, 10).ToArray();
+            ReadOnlySpan<byte> bytes = new ReadOnlySpan<byte>(arrayOfbytes);
+            ionValues.Add(valueFactory.NewClob(bytes));
+            ionValues.Add(valueFactory.NewBlob(bytes));
+
+            foreach (var ionValue in ionValues)
+            {
+                ionValue.AddTypeAnnotation("annotation");
+            }
+
+            using var writer = IonBinaryWriterBuilder.Build(new MemoryStream());
+            foreach (var ionValue in ionValues)
+            {
+                ionValue.WriteTo(writer);
+            }
+            writer.Finish();
         }
     }
 }

--- a/Amazon.IonDotnet.Tests/Internals/BinaryWriterTest.cs
+++ b/Amazon.IonDotnet.Tests/Internals/BinaryWriterTest.cs
@@ -476,13 +476,22 @@ namespace Amazon.IonDotnet.Tests.Internals
                 ionValue.AddTypeAnnotation("annotation");
             }
 
-            using (var writer = IonBinaryWriterBuilder.Build(new MemoryStream()))
+            var ms = new MemoryStream();
+            var writer = IonBinaryWriterBuilder.Build(ms);
+            using (writer)
             {
                 foreach (var ionValue in ionValues)
                 {
                     ionValue.WriteTo(writer);
                 }
                 writer.Finish();
+            }
+
+            var reader = new UserBinaryReader(new MemoryStream(ms.GetWrittenBuffer()));
+            while (reader.MoveNext() != IonType.None)
+            {
+                var annotation = reader.GetTypeAnnotations();
+                Assert.AreEqual("annotation", annotation[0]);
             }
         }
     }

--- a/Amazon.IonDotnet.Tests/Internals/BinaryWriterTest.cs
+++ b/Amazon.IonDotnet.Tests/Internals/BinaryWriterTest.cs
@@ -476,12 +476,14 @@ namespace Amazon.IonDotnet.Tests.Internals
                 ionValue.AddTypeAnnotation("annotation");
             }
 
-            using var writer = IonBinaryWriterBuilder.Build(new MemoryStream());
-            foreach (var ionValue in ionValues)
+            using (var writer = IonBinaryWriterBuilder.Build(new MemoryStream()))
             {
-                ionValue.WriteTo(writer);
+                foreach (var ionValue in ionValues)
+                {
+                    ionValue.WriteTo(writer);
+                }
+                writer.Finish();
             }
-            writer.Finish();
         }
     }
 }

--- a/Amazon.IonDotnet/Internals/Binary/RawBinaryWriter.cs
+++ b/Amazon.IonDotnet/Internals/Binary/RawBinaryWriter.cs
@@ -229,6 +229,7 @@ namespace Amazon.IonDotnet.Internals.Binary
             this.PrepareValue();
             this.containerStack.IncreaseCurrentContainerLength(1);
             this.dataBuffer.WriteByte(value ? BoolTrueByte : BoolFalseByte);
+            this.FinishValue();
         }
 
         public void WriteInt(long value)


### PR DESCRIPTION
*Issue #108 *

*Description of changes:*
Missing FinishVakue call after writing a boolean value to a binary writer.

resolves #108 