### PR TITLE
Check symbol table range before writing

### DIFF
--- a/Amazon.IonDotnet.Tests/Common/SymTabUtils.cs
+++ b/Amazon.IonDotnet.Tests/Common/SymTabUtils.cs
@@ -13,6 +13,9 @@
  * permissions and limitations under the License.
  */
 
+using Amazon.IonDotnet.Builders;
+using Amazon.IonDotnet.Tree;
+using Amazon.IonDotnet.Tree.Impl;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Amazon.IonDotnet.Tests.Common
@@ -43,6 +46,23 @@ namespace Amazon.IonDotnet.Tests.Common
             token = symbolTable.Intern(text);
             Assert.AreEqual(SymbolToken.UnknownSid, token.Sid);
             Assert.AreEqual(text, token.Text);
+        }
+
+        public static IIonValue DatagramWithOutOfRangeSymbolsInSymbolTable()
+        {
+            var text =
+                SystemSymbols.IonSymbolTable + "::" +
+                "{" +
+                "symbols:[\"s1\"]" +
+                "}\n" +
+                "$10\n";
+
+            var ionValueFactory = new ValueFactory();
+            var datagram = IonLoader.Default.Load(text);
+            datagram.Add(ionValueFactory.NewSymbol("with_unknown_sid"));
+            datagram.Add(ionValueFactory.NewSymbol(new SymbolToken(null, 12)));
+
+            return datagram;
         }
     }
 }

--- a/Amazon.IonDotnet.Tests/Internals/BinaryWriterTest.cs
+++ b/Amazon.IonDotnet.Tests/Internals/BinaryWriterTest.cs
@@ -494,5 +494,18 @@ namespace Amazon.IonDotnet.Tests.Internals
                 Assert.AreEqual("annotation", annotation[0]);
             }
         }
+
+        [TestMethod]
+        [ExpectedException(typeof(UnknownSymbolException))]
+        public void WriteSymbolWithSymbolTableOutOfRange()
+        {
+            var datagram = SymTabUtils.DatagramWithOutOfRangeSymbolsInSymbolTable();
+
+            var memStream = new MemoryStream();
+            var binaryWriter = IonBinaryWriterBuilder.Build(memStream);
+            // Should throw exception as sid 12 in datagram exceeds the max ID of the symbol table currently in scope 
+            datagram.WriteTo(binaryWriter);
+            binaryWriter.Finish();
+        }
     }
 }

--- a/Amazon.IonDotnet.Tests/Internals/TextWriterTest.cs
+++ b/Amazon.IonDotnet.Tests/Internals/TextWriterTest.cs
@@ -81,5 +81,28 @@ namespace Amazon.IonDotnet.Tests.Internals
             var actual = sw.ToString();
             Assert.AreEqual(expected, actual);
         }
+
+        [TestMethod]
+        [ExpectedException(typeof(UnknownSymbolException))]
+        public void WriteSymbolWithSymbolTableOutOfRange()
+        {
+            var text =
+                SystemSymbols.IonSymbolTable + "::" +
+                "{" +
+                "symbols:[\"s1\"]" +
+                "}\n" +
+                "$10\n";
+
+            var ionValueFactory = new ValueFactory();
+            var datagram = IonLoader.Default.Load(text);
+            datagram.Add(ionValueFactory.NewSymbol("with_unknown_sid"));
+            datagram.Add(ionValueFactory.NewSymbol(new SymbolToken(null, 12)));
+
+            var sw = new StringWriter();
+            var textWriter = IonTextWriterBuilder.Build(sw);
+            // Should trhow exception as sid 12 exceeds the max ID of the symbol table currently in scope 
+            datagram.WriteTo(textWriter);
+            textWriter.Finish();
+        }
     }
 }

--- a/Amazon.IonDotnet.Tests/Internals/TextWriterTest.cs
+++ b/Amazon.IonDotnet.Tests/Internals/TextWriterTest.cs
@@ -81,5 +81,28 @@ namespace Amazon.IonDotnet.Tests.Internals
             var actual = sw.ToString();
             Assert.AreEqual(expected, actual);
         }
+
+        [TestMethod]
+        [ExpectedException(typeof(UnknownSymbolException))]
+        public void WriteSymbolWithSymbolTableOutOfRange()
+        {
+            var text =
+                SystemSymbols.IonSymbolTable + "::" +
+                "{" +
+                "symbols:[\"s1\"]" +
+                "}\n" +
+                "$10\n";
+
+            var ionValueFactory = new ValueFactory();
+            var datagram = IonLoader.Default.Load(text);
+            datagram.Add(ionValueFactory.NewSymbol("with_unknown_sid"));
+            datagram.Add(ionValueFactory.NewSymbol(new SymbolToken(null, 12)));
+
+            var sw = new StringWriter();
+            var textWriter = IonTextWriterBuilder.Build(sw);
+            // Should trhow exception as sid 12 exceeds the max ID of the symbol table currently in scope 
+            datagram.WriteTo(textWriter); 
+            textWriter.Finish();
+        }
     }
 }

--- a/Amazon.IonDotnet.Tests/Internals/TextWriterTest.cs
+++ b/Amazon.IonDotnet.Tests/Internals/TextWriterTest.cs
@@ -16,6 +16,7 @@
 using System;
 using System.IO;
 using Amazon.IonDotnet.Builders;
+using Amazon.IonDotnet.Tests.Common;
 using Amazon.IonDotnet.Tree.Impl;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -86,21 +87,11 @@ namespace Amazon.IonDotnet.Tests.Internals
         [ExpectedException(typeof(UnknownSymbolException))]
         public void WriteSymbolWithSymbolTableOutOfRange()
         {
-            var text =
-                SystemSymbols.IonSymbolTable + "::" +
-                "{" +
-                "symbols:[\"s1\"]" +
-                "}\n" +
-                "$10\n";
-
-            var ionValueFactory = new ValueFactory();
-            var datagram = IonLoader.Default.Load(text);
-            datagram.Add(ionValueFactory.NewSymbol("with_unknown_sid"));
-            datagram.Add(ionValueFactory.NewSymbol(new SymbolToken(null, 12)));
+            var datagram = SymTabUtils.DatagramWithOutOfRangeSymbolsInSymbolTable();
 
             var sw = new StringWriter();
             var textWriter = IonTextWriterBuilder.Build(sw);
-            // Should trhow exception as sid 12 exceeds the max ID of the symbol table currently in scope 
+            // Should throw exception as sid 12 in datagram exceeds the max ID of the symbol table currently in scope 
             datagram.WriteTo(textWriter);
             textWriter.Finish();
         }

--- a/Amazon.IonDotnet.Tests/Internals/TextWriterTest.cs
+++ b/Amazon.IonDotnet.Tests/Internals/TextWriterTest.cs
@@ -81,28 +81,5 @@ namespace Amazon.IonDotnet.Tests.Internals
             var actual = sw.ToString();
             Assert.AreEqual(expected, actual);
         }
-
-        [TestMethod]
-        [ExpectedException(typeof(UnknownSymbolException))]
-        public void WriteSymbolWithSymbolTableOutOfRange()
-        {
-            var text =
-                SystemSymbols.IonSymbolTable + "::" +
-                "{" +
-                "symbols:[\"s1\"]" +
-                "}\n" +
-                "$10\n";
-
-            var ionValueFactory = new ValueFactory();
-            var datagram = IonLoader.Default.Load(text);
-            datagram.Add(ionValueFactory.NewSymbol("with_unknown_sid"));
-            datagram.Add(ionValueFactory.NewSymbol(new SymbolToken(null, 12)));
-
-            var sw = new StringWriter();
-            var textWriter = IonTextWriterBuilder.Build(sw);
-            // Should trhow exception as sid 12 exceeds the max ID of the symbol table currently in scope 
-            datagram.WriteTo(textWriter); 
-            textWriter.Finish();
-        }
     }
 }

--- a/Amazon.IonDotnet/IIonReader.cs
+++ b/Amazon.IonDotnet/IIonReader.cs
@@ -134,7 +134,7 @@ namespace Amazon.IonDotnet
         /// <returns>Current string value.</returns>
         string StringValue();
 
-        /// <summary>Returns the current value as a SymbolToken.</summary>
+        /// <summary>Returns th current value as a SymbolToken.</summary>
         /// <returns>Current symbol value.</returns>
         SymbolToken SymbolValue();
 

--- a/Amazon.IonDotnet/IIonReader.cs
+++ b/Amazon.IonDotnet/IIonReader.cs
@@ -134,7 +134,7 @@ namespace Amazon.IonDotnet
         /// <returns>Current string value.</returns>
         string StringValue();
 
-        /// <summary>Returns th current value as a SymbolToken.</summary>
+        /// <summary>Returns the current value as a SymbolToken.</summary>
         /// <returns>Current symbol value.</returns>
         SymbolToken SymbolValue();
 

--- a/Amazon.IonDotnet/Internals/ReaderLocalTable.cs
+++ b/Amazon.IonDotnet/Internals/ReaderLocalTable.cs
@@ -26,8 +26,8 @@ namespace Amazon.IonDotnet.Internals
     internal class ReaderLocalTable : ISymbolTable
     {
         internal readonly List<ISymbolTable> Imports;
+        internal readonly List<string> OwnSymbols = new List<string>();
 
-        private readonly List<string> ownSymbols = new List<string>();
         private int importedMaxId;
 
         internal ReaderLocalTable(ISymbolTable systemTable)
@@ -52,13 +52,13 @@ namespace Amazon.IonDotnet.Internals
 
         public string IonVersionId => this.GetSystemTable().IonVersionId;
 
-        public int MaxId => this.importedMaxId + this.ownSymbols.Count;
+        public int MaxId => this.importedMaxId + this.OwnSymbols.Count;
 
         public static ISymbolTable ImportReaderTable(IIonReader reader, ICatalog catalog, bool isOnStruct)
         {
             var table = reader.GetSymbolTable() as ReaderLocalTable ?? new ReaderLocalTable(reader.GetSymbolTable());
             var imports = table.Imports;
-            var symbols = table.ownSymbols;
+            var symbols = table.OwnSymbols;
             var newSymbols = new List<string>();
 
             if (!isOnStruct)
@@ -192,7 +192,7 @@ namespace Amazon.IonDotnet.Internals
                 }
             }
 
-            if (this.ownSymbols.Contains(text))
+            if (this.OwnSymbols.Contains(text))
             {
                 return new SymbolToken(text, SymbolToken.UnknownSid);
             }
@@ -214,9 +214,9 @@ namespace Amazon.IonDotnet.Internals
                 offset += import.MaxId;
             }
 
-            for (var i = 0; i < this.ownSymbols.Count; i++)
+            for (var i = 0; i < this.OwnSymbols.Count; i++)
             {
-                if (this.ownSymbols[i] == text)
+                if (this.OwnSymbols[i] == text)
                 {
                     return i + 1 + this.importedMaxId;
                 }
@@ -234,7 +234,7 @@ namespace Amazon.IonDotnet.Internals
 
             if (sid > this.importedMaxId)
             {
-                return this.ownSymbols[sid - this.importedMaxId - 1];
+                return this.OwnSymbols[sid - this.importedMaxId - 1];
             }
 
             var offset = 0;
@@ -254,11 +254,11 @@ namespace Amazon.IonDotnet.Internals
 
         public void WriteTo(IIonWriter writer) => writer.WriteValue(new SymbolTableReader(this));
 
-        public IEnumerable<string> GetDeclaredSymbolNames() => this.ownSymbols;
+        public IEnumerable<string> GetDeclaredSymbolNames() => this.OwnSymbols;
 
         /// <summary>
         /// Refresh the local symbol table to a valid state. Typically called after <see cref="Imports"/>
-        /// and <see cref="ownSymbols"/> has been mutated.
+        /// and <see cref="OwnSymbols"/> has been mutated.
         /// </summary>
         internal void Refresh()
         {

--- a/Amazon.IonDotnet/Tree/Impl/IonSequence.cs
+++ b/Amazon.IonDotnet/Tree/Impl/IonSequence.cs
@@ -220,43 +220,14 @@ namespace Amazon.IonDotnet.Tree.Impl
                 writer.StepIn(type);
             }
 
-            var ownSymbolsCount = 0;
-            List<IIonValue> symbolTokens = new List<IIonValue>();
             foreach (var val in this.children)
             {
-                if (val.Type() == IonType.Symbol)
-                {
-                    this.HandleSymbols(val, symbolTokens, ref ownSymbolsCount);
-                }
-                else
-                {
-                    val.WriteTo(writer);
-                }
-            }
-
-            var maxSymbolCount = SystemSymbols.Ion10MaxId + ownSymbolsCount;
-            foreach (var symbol in symbolTokens)
-            {
-                if (symbol.SymbolValue.Text == null && symbol.SymbolValue.Sid > maxSymbolCount)
-                {
-                    throw new UnknownSymbolException(symbol.SymbolValue.Sid);
-                }
-
-                symbol.WriteTo(writer);
+                val.WriteTo(writer);
             }
 
             if (type != IonType.Datagram)
             {
                 writer.StepOut();
-            }
-        }
-
-        private void HandleSymbols(IIonValue val, List<IIonValue> symbolTokens, ref int ownSymbolsCount)
-        {
-            symbolTokens.Add(val);
-            if (val.SymbolValue.Text != null && val.SymbolValue.Sid > 0)
-            {
-                ownSymbolsCount++;
             }
         }
     }

--- a/Amazon.IonDotnet/Tree/Impl/IonSequence.cs
+++ b/Amazon.IonDotnet/Tree/Impl/IonSequence.cs
@@ -220,14 +220,43 @@ namespace Amazon.IonDotnet.Tree.Impl
                 writer.StepIn(type);
             }
 
+            var ownSymbolsCount = 0;
+            List<IIonValue> symbolTokens = new List<IIonValue>();
             foreach (var val in this.children)
             {
-                val.WriteTo(writer);
+                if (val.Type() == IonType.Symbol)
+                {
+                    this.HandleSymbols(val, symbolTokens, ref ownSymbolsCount);
+                }
+                else
+                {
+                    val.WriteTo(writer);
+                }
+            }
+
+            var maxSymbolCount = SystemSymbols.Ion10MaxId + ownSymbolsCount;
+            foreach (var symbol in symbolTokens)
+            {
+                if (symbol.SymbolValue.Text == null && symbol.SymbolValue.Sid > maxSymbolCount)
+                {
+                    throw new UnknownSymbolException(symbol.SymbolValue.Sid);
+                }
+
+                symbol.WriteTo(writer);
             }
 
             if (type != IonType.Datagram)
             {
                 writer.StepOut();
+            }
+        }
+
+        private void HandleSymbols(IIonValue val, List<IIonValue> symbolTokens, ref int ownSymbolsCount)
+        {
+            symbolTokens.Add(val);
+            if (val.SymbolValue.Text != null && val.SymbolValue.Sid > 0)
+            {
+                ownSymbolsCount++;
             }
         }
     }


### PR DESCRIPTION
Before writing symbols in writer, we must check if the Sid does not exceed the max ID of the symbol table currently in scope.

In the writer, the symbol table is created incrementally as new symbols are provided through the writer APIs. For each symbol, we update the table and check the maximum id.

resolves #104 
