### PR TITLE
Reset Lob value status after each value is written

### DIFF
--- a/Amazon.IonDotnet/Internals/Binary/RawBinaryReader.cs
+++ b/Amazon.IonDotnet/Internals/Binary/RawBinaryReader.cs
@@ -688,6 +688,7 @@ namespace Amazon.IonDotnet.Internals.Binary
             this.valueVariant.Clear();
             this.valueFieldId = SymbolToken.UnknownSid;
             this.hasSymbolTableAnnotation = false;
+            this.valueLobReady = false;
         }
 
         private void MoveNextRaw()
@@ -848,11 +849,6 @@ namespace Amazon.IonDotnet.Internals.Binary
             }
 
             var tid = BinaryConstants.GetTypeCode(tdRead);
-            if (tid == BinaryConstants.TidClob)
-            {
-                Console.WriteLine("trouble");
-            }
-
             var len = BinaryConstants.GetLowNibble(tdRead);
             if (tid == BinaryConstants.TidNull && len != BinaryConstants.LnIsNull)
             {


### PR DESCRIPTION
resolves #113 
- Remove print statement
- Status of Lob values should be reset in cleanup method of binary reader or it can affect consecutive clobs/lobs in the reader ([similar logic in Java](https://github.com/amzn/ion-java/blob/master/src/com/amazon/ion/impl/IonReaderBinaryRawX.java#L451))
