### PR TITLE
Make timestamp parsing locale-independent

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           submodules: recursive
       - name: Setup .Net
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v1.6
         with:
           dotnet-version: ${{ matrix.dotnet }}
       - name: Project Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           submodules: recursive
       - name: Setup .Net
-        uses: actions/setup-dotnet@v1.6
+        uses: actions/setup-dotnet@v1.6.0
         with:
           dotnet-version: ${{ matrix.dotnet }}
       - name: Project Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           submodules: recursive
       - name: Setup .Net
-        uses: actions/setup-dotnet@v1.6.0
+        uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet }}
       - name: Project Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Project Build
         run: dotnet build --configuration Release
       - name: Project Test
-        run: dotnet test --configuration Release --no-build --no-restore --verbosity normal
+        run: dotnet test --configuration Release --no-build --no-restore --verbosity normal --framework ${{ matrix.dotnet }}

--- a/Amazon.IonDotnet/Timestamp.cs
+++ b/Amazon.IonDotnet/Timestamp.cs
@@ -17,6 +17,7 @@ namespace Amazon.IonDotnet
 {
     using System;
     using System.Diagnostics;
+    using System.Globalization;
 
     /// <inheritdoc cref="IEquatable{T}" />
     /// <summary>
@@ -550,7 +551,8 @@ namespace Amazon.IonDotnet
                 return false;
             }
 
-            return decimal.TryParse(s.Substring(offset, length), out output);
+            string decimalText = s.Substring(offset, length);
+            return decimal.TryParse(decimalText, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out output);
         }
 
         /// <summary>


### PR DESCRIPTION
*Issue #, if available:* #128 

*Description of changes:*

Previously, `Timestamp.parse` used [`decimal#TryParse(String, Decimal)`](https://docs.microsoft.com/en-us/dotnet/api/system.decimal.tryparse?view=netcore-2.1#System_Decimal_TryParse_System_String_System_Decimal__) to read in the seconds portion of the given timestamp. This method defers to the configured `CurrentCulture` for some parsing rules and would break in locales that use a comma instead of a decimal point for non-integer values.

This PR replaces the usage of `decimal#TryParse(String, Decimal)` with [`decimal#TryParse(String, NumberStyles, IFormatProvider, Decimal)`](https://docs.microsoft.com/en-us/dotnet/api/system.decimal.tryparse?view=netcore-2.1#System_Decimal_TryParse_System_String_System_Globalization_NumberStyles_System_IFormatProvider_System_Decimal__), allowing us to use [`InvariantCulture`](https://docs.microsoft.com/en-us/dotnet/api/system.globalization.cultureinfo.invariantculture?view=netcore-3.1) instead of the current thread's configured culture.

It also modifies the `TimeZone_Hour_Minute` unit tests to avoid constructing/slicing/comparing `string` representations of timestamps as `ToString` also depends on the configured locale.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
