### PR TITLE
Fixes JSON down converter decimal spec issue.

### DIFF
--- a/Amazon.IonDotnet.Tests/Internals/TextWriterJsonTest.cs
+++ b/Amazon.IonDotnet.Tests/Internals/TextWriterJsonTest.cs
@@ -47,6 +47,21 @@ namespace Amazon.IonDotnet.Tests.Internals
         }
 
         [TestMethod]
+        [DataRow("0.2")]
+        [DataRow("2.d-1")]
+        [DataRow("2d-1")]
+        public void TestMismatchDecimal(string decimalString)
+        {
+            var bigDecimal = BigDecimal.Parse(decimalString);
+            
+            value.SetField("value", factory.NewDecimal(bigDecimal));
+            var reader = IonReaderBuilder.Build(value);
+            jsonWriter.WriteValues(reader);
+            
+            Assert.AreEqual("{\"value\":2e-1}", this.sw.ToString());
+        }
+
+        [TestMethod]
         public void TestGenericNull()
         {
             value.SetField("value", factory.NewNull());

--- a/Amazon.IonDotnet.Tests/Internals/TextWriterJsonTest.cs
+++ b/Amazon.IonDotnet.Tests/Internals/TextWriterJsonTest.cs
@@ -50,7 +50,7 @@ namespace Amazon.IonDotnet.Tests.Internals
         [DataRow("0.2")]
         [DataRow("2.d-1")]
         [DataRow("2d-1")]
-        public void TestMismatchDecimal(string decimalString)
+        public void TestInvalidJsonDecimalFromIon(string decimalString)
         {
             var bigDecimal = BigDecimal.Parse(decimalString);
             

--- a/Amazon.IonDotnet/Internals/Text/IonTextWriter.cs
+++ b/Amazon.IonDotnet/Internals/Text/IonTextWriter.cs
@@ -222,8 +222,8 @@ namespace Amazon.IonDotnet.Internals.Text
                 // Since Ion Decimal allows an exponent integer following '.' (e.g. 2.d-1) while JSON doesn't, we
                 // should make sure JSON down converter doesn't write any decimal number with '.' immediately
                 // followed by 'e'.
-                var index = decimalString.IndexOf('.', 0);
-                if (index != -1 && decimalString[index + 1] == 'e')
+                var index = decimalString.IndexOf(".e", 0);
+                if (index != -1)
                 {
                     decimalString = decimalString.Remove(index, 1);
                 }

--- a/Amazon.IonDotnet/Internals/Text/IonTextWriter.cs
+++ b/Amazon.IonDotnet/Internals/Text/IonTextWriter.cs
@@ -218,6 +218,16 @@ namespace Amazon.IonDotnet.Internals.Text
             {
                 var decimalString = value.ToString();
                 decimalString = decimalString.Replace('d', 'e');
+
+                // Since Ion Decimal allows an exponent integer following '.' (e.g. 2.d-1) while JSON doesn't, we
+                // should make sure JSON down converter doesn't write any decimal number with '.' immediately
+                // followed by 'e'.
+                var index = decimalString.IndexOf('.', 0);
+                if (index != -1 && decimalString[index + 1] == 'e')
+                {
+                    decimalString = decimalString.Remove(index, 1);
+                }
+
                 this.textWriter.Write(decimalString);
             }
             else


### PR DESCRIPTION
### Description:
Ion allows `2.d-1` indicating `0.2` while JSON doesn't. When IonDoNet JSON downconverter converts `2.d-1` to JSON decimal, it returns `2.e-1` which is an invalid JSON decimal since exponent `e` can't follow `.` directly. Refer to [JSON spec](https://www.json.org/json-en.html) for more details.

So IonDotNet JSON down converter should return a valid JSON decimal (e.g. `2e-1`). 
 


&nbsp;
&nbsp;
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
