### PR TITLE
`IonTextWriterBuilder` produces invalid JSON with different cultures

### DIFF
--- a/Amazon.IonDotnet.Tests/Internals/BigDecimalTest.cs
+++ b/Amazon.IonDotnet.Tests/Internals/BigDecimalTest.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Numerics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -229,6 +230,17 @@ namespace Amazon.IonDotnet.Tests.Internals
         {
             var parsed = BigDecimal.Parse(text);
             Assert.AreEqual(expected, parsed.ToString());
+        }
+
+        [TestMethod]
+        [DataRow("0.65", "6.5e-1", "en-US")]
+        [DataRow("0.65", "6.5e-1", "sv-SE")]
+        public void ToString_Different_Cultures(string text, string expected, string culture)
+        {
+            CultureInfo originalCulture = System.Threading.Thread.CurrentThread.CurrentCulture;
+            System.Threading.Thread.CurrentThread.CurrentCulture = new CultureInfo(culture);
+
+            System.Threading.Thread.CurrentThread.CurrentCulture = originalCulture;
         }
 
         [TestMethod]

--- a/Amazon.IonDotnet.Tests/Internals/TextWriterJsonTest.cs
+++ b/Amazon.IonDotnet.Tests/Internals/TextWriterJsonTest.cs
@@ -18,6 +18,7 @@ using Amazon.IonDotnet.Tree;
 using Amazon.IonDotnet.Tree.Impl;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Globalization;
 using System.IO;
 using System.Text;
 
@@ -225,6 +226,25 @@ namespace Amazon.IonDotnet.Tests.Internals
             var reader = IonReaderBuilder.Build(value);
             jsonWriter.WriteValues(reader);
             Assert.AreEqual("{\"value\":\"symbol\"}", this.sw.ToString());
+        }
+
+        [TestMethod]
+        [DataRow("0.65", "en-US")]
+        [DataRow("6.5d-1", "en-US")]
+        [DataRow("0.65", "sv-SE")]
+        [DataRow("6.5d-1", "sv-SE")]
+        public void TestInvalidJsonDecimalFromIonWithDifferentCultures(string decimalString, string culture)
+        {
+            CultureInfo originalCulture = System.Threading.Thread.CurrentThread.CurrentCulture;
+            System.Threading.Thread.CurrentThread.CurrentCulture = new CultureInfo(culture);
+            var bigDecimal = BigDecimal.Parse(decimalString);
+
+            value.SetField("value", factory.NewDecimal(bigDecimal));
+            var reader = IonReaderBuilder.Build(value);
+            jsonWriter.WriteValues(reader);
+
+            Assert.AreEqual("{\"value\":6.5e-1}", this.sw.ToString());
+            System.Threading.Thread.CurrentThread.CurrentCulture = originalCulture;
         }
     }
 }

--- a/Amazon.IonDotnet/BigDecimal.cs
+++ b/Amazon.IonDotnet/BigDecimal.cs
@@ -452,7 +452,7 @@ namespace Amazon.IonDotnet
                     var d = this.Scale - (sb.Length - smallestDotIdx);
                     sb.Insert(smallestDotIdx, '.');
                     sb.Append('d');
-                    sb.Append(-d);
+                    sb.Append((-d).ToString(CultureInfo.InvariantCulture));
                 }
             }
 


### PR DESCRIPTION
*Issue #, if available:* #137

*Description of changes:* To summarize the core issue, some cultures parse negative integers differently. For example, "en-US" will return `-1` (dash) when `(-1).ToString();` is called. But "sv-SE" will return `−1` (minus sign). This can be observed in `BigDecimal.cs` on line 455: `sb.Append(-d);`. This line was changed to `sb.Append((-d).ToString(CultureInfo.InvariantCulture));`. Tests were added to `TextWriterJsonTest.cs` and `BigDecimalTest.cs` to ensure the correct behavior.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
