### PR TITLE
Adds GHA workflow to sign and publish releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,103 @@
+name: Ion DotNet Release
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "v*.*.*"
+
+jobs:
+  test:
+    name: Test
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ windows-latest ]
+        dotnet: ['2.1', '3.1']
+
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v2
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ matrix.dotnet }}
+
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+      - name: Unit test
+        run: dotnet test Amazon.IonDotnet.Test
+
+  release:
+    name: Release
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [test]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        dotnet: ['3.1']
+
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-skip-session-tagging: true
+          aws-region: us-west-2
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
+          role-duration-seconds: 900
+
+      - name: Git Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ matrix.dotnet }}
+
+      - name: Sign
+        run: |
+          dotnet build --configuration Release
+
+          # Push unsigned DLL to S3
+          version_id=$( aws s3api put-object --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }} --body Amazon.IonDotnet/bin/Release/netstandard2.0/Amazon.IonDotnet.dll  --acl bucket-owner-full-control | jq '.VersionId' )
+          job_id=""
+          # Attempt to get Job ID from bucket tagging, will retry up to 3 times before exiting with a failure code.
+          # Will sleep for 5 seconds between retries.
+          for (( i=0; i<3; i++ ))
+          do
+            # Get job ID
+            id=$( aws s3api get-object-tagging --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }} --version-id ${version_id} | jq -r '.TagSet[0].Value' )
+            if [ $id != "null" ]
+            then
+              job_id=$id
+              break
+            fi
+
+            sleep 5s
+          done
+
+          if [[ $job_id = "" ]]
+          then
+             echo "Exiting because unable to retrieve job ID"
+             exit 1
+          fi
+
+          # Poll signed S3 bucket to see if the signed artifact is there
+          aws s3api wait object-exists --bucket ${{ secrets.AWS_SIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }}-${job_id}
+
+          # Get signed DLL from S3
+          aws s3api get-object --bucket ${{ secrets.AWS_SIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }}-${job_id} Amazon.IonDotnet/bin/Release/netstandard2.0/Amazon.IonDotnet.dll
+
+      - name: Publish to NuGet
+        run: |
+          dotnet pack --configuration Release --no-build
+          dotnet nuget push Amazon.IonDotnet/bin/Release/Amazon.IonDotnet.*.nupkg --api-key ${{ secrets.AWS_NUGET_KEY }} --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

Adds a Github actions workflow to sign and publish releases on NuGet.
This is heavily copied from https://github.com/amzn/ion-object-mapper-dotnet/blob/main/.github/workflows/release.yml



_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
