### PR TITLE
Fix branch in CodeQL GitHub Actions workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,10 +8,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches: [ master ]
   schedule:
     - cron: '0 22 * * 4'
 


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Branch was set to 'main' as a result of a copy/paste error. This changes it to the correct branch for this repo, which is actually 'master'.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
