### PR TITLE
Fixes tests in CI release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,17 +20,16 @@ jobs:
     steps:
       - name: Git Checkout
         uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet }}
-
-      - name: Install dependencies
-        run: dotnet restore
       - name: Build
-        run: dotnet build --configuration Release --no-restore
+        run: dotnet build --configuration Release
       - name: Unit test
-        run: dotnet test Amazon.IonDotnet.Test
+        run: dotnet test --configuration Release --no-build --no-restore --verbosity normal --framework ${{ matrix.dotnet }}
 
   release:
     name: Release

--- a/Amazon.IonDotnet/Amazon.IonDotnet.csproj
+++ b/Amazon.IonDotnet/Amazon.IonDotnet.csproj
@@ -4,7 +4,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>7.3</LangVersion>
     <PackageId>Amazon.IonDotnet</PackageId>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
     <Authors>amazon-ion</Authors>
     <Company>Amazon.com</Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
*Issue #, if available:*

None

*Description of changes:*

Regular CI build/test is passing, but these tests failed. I discovered that there were some discrepancies between them, and so I have updated the workflow to match the tests in the regular CI build workflow.

At some point, we should address the redundancy in the workflows, and I've created an issue for that (https://github.com/amzn/ion-dotnet/issues/144).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
