### PR TITLE
Fixes infinite loop bugs in text parsing of lobs and strings.

### DIFF
--- a/Amazon.IonDotnet.Tests/Internals/TextScannerTest.cs
+++ b/Amazon.IonDotnet.Tests/Internals/TextScannerTest.cs
@@ -1,0 +1,171 @@
+using System;
+using System.IO;
+using System.Text;
+using Amazon.IonDotnet.Internals.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Amazon.IonDotnet.Tests.Internals
+{
+    [TestClass]
+    public class TextScannerTest
+    {
+        private TextScanner CreateScanner(string input)
+        {
+            var bytes = System.Text.Encoding.UTF8.GetBytes(input);
+            var stream = new MemoryStream(bytes);
+            var textStream = new UnicodeStream(stream);
+            return new TextScanner(textStream);
+        }
+
+        [TestMethod]
+        public void TestMalformedBlobHandling()
+        {
+            // Test simple malformed blob
+            var scanner = CreateScanner("{{");
+            Assert.ThrowsException<UnexpectedEofException>(() =>
+            {
+                scanner.NextToken();
+                while (scanner.Token != TextConstants.TokenEof)
+                {
+                    scanner.NextToken();
+                }
+            });
+
+            // Test the specific malformed input that caused the infinite loop
+            var hexString = "282f5959595959595959593a3a282b2727357b7b7b7b7b7b7b7b27272728fb2b272829";
+            var bytes = new byte[hexString.Length / 2];
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                bytes[i] = Convert.ToByte(hexString.Substring(i * 2, 2), 16);
+            }
+
+            var stream = new MemoryStream(bytes);
+            var textStream = new UnicodeStream(stream);
+            scanner = new TextScanner(textStream);
+
+            Assert.ThrowsException<UnexpectedEofException>(() =>
+            {
+                scanner.NextToken();
+                while (scanner.Token != TextConstants.TokenEof)
+                {
+                    scanner.NextToken();
+                }
+            });
+        }
+
+        [TestMethod]
+        public void TestSingleQuotedStringEofHandling()
+        {
+            // Test EOF in single-quoted string
+            var scanner = CreateScanner("'unterminated");
+            Assert.ThrowsException<UnexpectedEofException>(() =>
+            {
+                scanner.NextToken();
+                while (scanner.Token != TextConstants.TokenEof)
+                {
+                    scanner.NextToken();
+                }
+            });
+
+            // Test EOF after escape in single-quoted string
+            scanner = CreateScanner("'escaped\\");
+            Assert.ThrowsException<UnexpectedEofException>(() =>
+            {
+                scanner.NextToken();
+                while (scanner.Token != TextConstants.TokenEof)
+                {
+                    scanner.NextToken();
+                }
+            });
+        }
+
+        [TestMethod]
+        public void TestTripleQuotedStringEofHandling()
+        {
+            // Test EOF in triple-quoted string
+            var scanner = CreateScanner("'''unterminated");
+            Assert.ThrowsException<UnexpectedEofException>(() =>
+            {
+                scanner.NextToken();
+                while (scanner.Token != TextConstants.TokenEof)
+                {
+                    scanner.NextToken();
+                }
+            });
+
+            // Test EOF after partial triple quote
+            scanner = CreateScanner("'''content''");
+            Assert.ThrowsException<UnexpectedEofException>(() =>
+            {
+                scanner.NextToken();
+                while (scanner.Token != TextConstants.TokenEof)
+                {
+                    scanner.NextToken();
+                }
+            });
+
+            // Test EOF after escape in triple-quoted string
+            scanner = CreateScanner("'''escaped\\");
+            Assert.ThrowsException<UnexpectedEofException>(() =>
+            {
+                scanner.NextToken();
+                while (scanner.Token != TextConstants.TokenEof)
+                {
+                    scanner.NextToken();
+                }
+            });
+        }
+
+        [TestMethod]
+        public void TestDoubleQuotedStringEofHandling()
+        {
+            // Test EOF in double-quoted string
+            var scanner = CreateScanner("\"unterminated");
+            Assert.ThrowsException<UnexpectedEofException>(() =>
+            {
+                scanner.NextToken();
+                while (scanner.Token != TextConstants.TokenEof)
+                {
+                    scanner.NextToken();
+                }
+            });
+
+            // Test EOF after escape in double-quoted string
+            scanner = CreateScanner("\"escaped\\");
+            Assert.ThrowsException<UnexpectedEofException>(() =>
+            {
+                scanner.NextToken();
+                while (scanner.Token != TextConstants.TokenEof)
+                {
+                    scanner.NextToken();
+                }
+            });
+        }
+
+        [TestMethod]
+        public void TestMalformedClobHandling()
+        {
+            // Test malformed clob with missing closing braces
+            var scanner = CreateScanner("{{\"clob content\"");
+            Assert.ThrowsException<UnexpectedEofException>(() =>
+            {
+                scanner.NextToken();
+                while (scanner.Token != TextConstants.TokenEof)
+                {
+                    scanner.NextToken();
+                }
+            });
+
+            // Test malformed clob with triple quotes
+            scanner = CreateScanner("{{{'''clob content");
+            Assert.ThrowsException<UnexpectedEofException>(() =>
+            {
+                scanner.NextToken();
+                while (scanner.Token != TextConstants.TokenEof)
+                {
+                    scanner.NextToken();
+                }
+            });
+        }
+    }
+}

--- a/Amazon.IonDotnet/Internals/Text/TextScanner.cs
+++ b/Amazon.IonDotnet/Internals/Text/TextScanner.cs
@@ -202,7 +202,7 @@ namespace Amazon.IonDotnet.Internals.Text
             var c = this.SkipOverWhiteSpace(CommentStrategy.Break);
             while (true)
             {
-                if (c == TextConstants.TokenEof)
+                if (c == CharacterSequence.CharSeqEof)
                 {
                     throw new UnexpectedEofException();
                 }
@@ -217,7 +217,7 @@ namespace Amazon.IonDotnet.Internals.Text
             }
 
             c = this.ReadChar();
-            if (c == TextConstants.TokenEof)
+            if (c == CharacterSequence.CharSeqEof)
             {
                 throw new UnexpectedEofException();
             }
@@ -1006,7 +1006,7 @@ namespace Amazon.IonDotnet.Internals.Text
             var c = this.SkipOverWhiteSpace(CommentStrategy.Break);
             while (true)
             {
-                if (c == TextConstants.TokenEof)
+                if (c == CharacterSequence.CharSeqEof)
                 {
                     throw new UnexpectedEofException();
                 }
@@ -1020,7 +1020,8 @@ namespace Amazon.IonDotnet.Internals.Text
             }
 
             c = this.ReadChar();
-            if (c == TextConstants.TokenEof)
+
+            if (c == CharacterSequence.CharSeqEof)
             {
                 throw new UnexpectedEofException();
             }
@@ -1038,21 +1039,40 @@ namespace Amazon.IonDotnet.Internals.Text
                 var c = this.ReadChar();
                 switch (c)
                 {
-                    case -1:
+                    case CharacterSequence.CharSeqEof:
                         throw new UnexpectedEofException();
                     case '\\':
-                        this.ReadChar();
+                        var escaped = this.ReadChar();
+                        if (escaped == CharacterSequence.CharSeqEof)
+                        {
+                            throw new UnexpectedEofException();
+                        }
+
                         break;
                     case '\'':
                         c = this.ReadChar();
+                        if (c == CharacterSequence.CharSeqEof)
+                        {
+                            throw new UnexpectedEofException();
+                        }
 
                         // the 2nd '
                         if (c == '\'')
                         {
                             c = this.ReadChar();
+                            if (c == CharacterSequence.CharSeqEof)
+                            {
+                                throw new UnexpectedEofException();
+                            }
 
                             // the 3rd
-                            if (c == this.ReadChar())
+                            var next = this.ReadChar();
+                            if (next == CharacterSequence.CharSeqEof)
+                            {
+                                throw new UnexpectedEofException();
+                            }
+
+                            if (c == next)
                             {
                                 c = this.SkipOverWhiteSpace(commentStrategy);
                                 if (c == '\'' && this.Is2SingleQuotes())
@@ -1515,12 +1535,23 @@ namespace Amazon.IonDotnet.Internals.Text
                 var c = this.ReadStringChar(Characters.ProhibitionContext.None);
                 switch (c)
                 {
-                    case -1:
+                    case CharacterSequence.CharSeqEof:
                         throw new UnexpectedEofException();
                     case '\'':
-                        return this.ReadChar();
+                        var next = this.ReadChar();
+                        if (next == CharacterSequence.CharSeqEof)
+                        {
+                            throw new UnexpectedEofException();
+                        }
+
+                        return next;
                     case '\\':
-                        this.ReadChar();
+                        var escaped = this.ReadChar();
+                        if (escaped == CharacterSequence.CharSeqEof)
+                        {
+                            throw new UnexpectedEofException();
+                        }
+
                         break;
                 }
             }
@@ -1537,7 +1568,7 @@ namespace Amazon.IonDotnet.Internals.Text
                 var c = this.ReadStringChar(Characters.ProhibitionContext.None);
                 switch (c)
                 {
-                    case -1:
+                    case CharacterSequence.CharSeqEof:
                         throw new UnexpectedEofException();
                     case CharacterSequence.CharSeqEscapedNewlineSequence1:
                     case CharacterSequence.CharSeqEscapedNewlineSequence2:
@@ -1547,7 +1578,12 @@ namespace Amazon.IonDotnet.Internals.Text
                     case '"':
                         return;
                     case '\\':
-                        this.ReadChar();
+                        var escaped = this.ReadChar();
+                        if (escaped == CharacterSequence.CharSeqEof)
+                        {
+                            throw new UnexpectedEofException();
+                        }
+
                         break;
                 }
             }


### PR DESCRIPTION
### Description of changes:

The following is a GitHub Actions workflow for a commit that includes only the new test added by this PR. The tests are hanging forever. https://github.com/amazon-ion/ion-dotnet/actions/runs/15742521485/job/44371188161

The changes to the source in this PR fix those potential infinite loops by throwing `UnexpectedEofException` when `CharSeqEof` (a constant with value `-1`) is encountered in the middle of a token that is expected to be complete. Before, `TextConstants.TokenEof` (a constant with value `0`) was checked, causing a loop when the stream produced `-1` to indicate it had reached its end.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
