### PR TITLE
Adds deprecation notice to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://github.com/amzn/ion-dotnet/workflows/Ion%20DotNet%20CI/badge.svg)](https://github.com/amzn/ion-dotnet/actions?query=workflow%3A%22Ion+DotNet+CI%22)
 [![nuget version](https://img.shields.io/nuget/v/Amazon.IonDotnet)](https://www.nuget.org/packages/Amazon.IonDotnet)
 
-As of 8/20/2024, this library is deprecated and will not receive further updates. Users should consider migrating to [other Ion solutions](https://github.com/orgs/amazon-ion/repositories?type=all).
+As of 8/20/2024, this library is deprecated and will not receive further updates. Users should consider migrating to [other Ion solutions](https://amazon-ion.github.io/ion-docs/libs.html).
 
 Amazon Ion ( http://amzn.github.io/ion-docs/ ) library for .NET
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-## Ion .NET
+## Ion .NET (Deprecated)
 
 [![Build Status](https://github.com/amzn/ion-dotnet/workflows/Ion%20DotNet%20CI/badge.svg)](https://github.com/amzn/ion-dotnet/actions?query=workflow%3A%22Ion+DotNet+CI%22)
 [![nuget version](https://img.shields.io/nuget/v/Amazon.IonDotnet)](https://www.nuget.org/packages/Amazon.IonDotnet)
+
+As of 8/20/2024, this library is deprecated and will not receive further updates. Users should consider migrating to [other Ion solutions](https://github.com/orgs/amazon-ion/repositories?type=all).
 
 Amazon Ion ( http://amzn.github.io/ion-docs/ ) library for .NET
 


### PR DESCRIPTION
This library was primarily intended to support users of QLDB, which provided a DotNet driver. With the sunsetting of QLDB at the end of July, developer resources are now better spent on other Ion libraries.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
